### PR TITLE
Add fee rewards manager to possim

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -102,8 +102,9 @@ local_resource(
 local_resource(
     "deploy-fee-manager-contracts",
     cmd="python3 -m eth_possim deploy-fee-manager-contracts",
-    deps=["deploy-deposit-contract"] + lh_beacon_nodes,
-    allow_parallel=False,
+    deps=lh_beacon_nodes,
+    resource_deps=["deploy-deposit-contract"],
+    allow_parallel=True,
 )
 
 # Deploy validator nodes

--- a/Tiltfile
+++ b/Tiltfile
@@ -98,6 +98,14 @@ local_resource(
     allow_parallel=True,
 )
 
+# Deploy fee manager library and main contract.
+local_resource(
+    "deploy-fee-manager-contracts",
+    cmd="python3 -m eth_possim deploy-fee-manager-contracts",
+    deps=lh_beacon_nodes,
+    allow_parallel=True,
+)
+
 # Deploy validator nodes
 for idx in range(cfg["cl"]["lh_node_count"]):
     node_name = "val-lh-{}".format(idx)

--- a/Tiltfile
+++ b/Tiltfile
@@ -102,8 +102,8 @@ local_resource(
 local_resource(
     "deploy-fee-manager-contracts",
     cmd="python3 -m eth_possim deploy-fee-manager-contracts",
-    deps=lh_beacon_nodes,
-    allow_parallel=True,
+    deps=["deploy-deposit-contract"] + lh_beacon_nodes,
+    allow_parallel=False,
 )
 
 # Deploy validator nodes

--- a/eth_possim/__main__.py
+++ b/eth_possim/__main__.py
@@ -8,7 +8,7 @@ import eth_possim
 from eth_possim.config import initialise_privatenet
 from eth_possim.config.load import load_configuration
 from eth_possim.config.patch import patch_cl_cfg
-from eth_possim.contracts import deploy_contract_onchain
+from eth_possim.contracts import deploy_contract_onchain, deploy_compiled_contract
 from eth_possim.deposit import load_initial_deposit_tree
 from eth_possim.utils import ensure_dir_exists
 
@@ -73,6 +73,57 @@ def deploy_batch_deposit_contract(rpc: str):
     with open("./.data/configuration.yaml", "w") as f:
         yaml.dump(cfg, f)
 
+@cli.command()
+@click.option("--rpc", help="RPC endpoint URL address.", default="")
+def deploy_fee_manager_contracts(rpc: str):
+    """Deploys the fee manager contracts: library and contract."""
+
+    with open("./.data/configuration.yaml", "r") as f:
+        cfg = yaml.safe_load(f)
+    if not rpc:
+        rpc = f"http://localhost:{cfg['haproxy']['el']['port_geth_rpc']}"
+
+    fee_manager_library_address = deploy_compiled_contract(
+        cfg=cfg,
+        rpc=rpc,
+        foundry_json_path=f"{cfg['resources']}/ethereum_compiled_contracts/CalculateAndSendRewards.json",
+    )
+
+    # Patch and write back `configuration.yaml`
+    cfg["cl"]["fee_manager_library_address"] = fee_manager_library_address
+
+    fee_manager_address = deploy_compiled_contract(
+        cfg=cfg,
+        rpc=rpc,
+        foundry_json_path=f"{cfg['resources']}/ethereum_compiled_contracts/FeeRewardsManager.json",
+        args=[2800],
+        libraries=[("__$c56d76a1417c078a963cba4fa22c45184c$__", fee_manager_library_address)]
+    )
+    cfg["cl"]["fee_manager_address"] = fee_manager_address
+
+    with open("./.data/configuration.yaml", "w") as f:
+        yaml.dump(cfg, f)
+
+@cli.command()
+@click.option("--rpc", help="RPC endpoint URL address.", default="")
+@click.option("--path", help="Path to the contract source.")
+@click.option("--cfg-key-address", help="Key in which to save the contract address.")
+@click.option("--library", multiple=True, type=(str, str), help="Libraries to be replaced in the bytecode contract in the format key value")
+@click.argument("args", nargs=-1)
+def deploy_contract_bytecode(rpc: str, path: str, cfg_key_address: str, args: list, library: list):
+    """Deploys a contract by the compiled bytecode and abi."""
+
+    with open("./.data/configuration.yaml", "r") as f:
+        cfg = yaml.safe_load(f)
+    if not rpc:
+        rpc = f"http://localhost:{cfg['haproxy']['el']['port_geth_rpc']}"
+
+    contract_address = deploy_compiled_contract(cfg=cfg, rpc=rpc, foundry_json_path=path, args=args, libraries=library)
+
+    # Patch and write back `configuration.yaml`
+    cfg["cl"][cfg_key_address] = contract_address
+    with open("./.data/configuration.yaml", "w") as f:
+        yaml.dump(cfg, f)
 
 @cli.command()
 @click.option("--rpc", help="RPC endpoint URL address.", default="")

--- a/eth_possim/contracts.py
+++ b/eth_possim/contracts.py
@@ -1,12 +1,58 @@
 import binascii
+import json
 import logging
 import solcx
 import web3
 import re
+from typing import List, Tuple
 
 
 logger = logging.getLogger(__name__)
 
+def deploy_compiled_contract(cfg: dict, rpc: str, foundry_json_path: str, args: list = [], libraries: List[Tuple[str, str]]  = []) -> str:
+    with open(foundry_json_path, "r") as f:
+        foundry_json = json.loads(f.read())
+    
+    bytecode_str = foundry_json["bytecode"]["object"][2:]
+    for library in libraries:
+        # Skip 0x from the library address.
+       bytecode_str = bytecode_str.replace(library[0], library[1][2:])
+    bytecode = binascii.unhexlify(bytecode_str)
+        
+    abi = foundry_json["abi"]
+
+    w3 = web3.Web3(web3.Web3.HTTPProvider(rpc))
+    w3.middleware_onion.inject(
+        web3.middleware.geth_poa_middleware,
+        layer=0,
+    )
+
+    contract = w3.eth.contract(abi=abi, bytecode=bytecode)
+    account = w3.eth.account.from_key(cfg["el"]["funder"]["private_key"])
+    w3.eth.default_account = account
+    nonce = w3.eth.get_transaction_count(account.address)
+
+    deploy_tx = contract.constructor(*args).build_transaction(
+        {
+            "chainId": cfg["el"]["chain_id"],
+            # "gas": Let the function estimate gas.
+            # "gasPrice": Let the function estimate gas price.
+            "from": account.address,
+            "nonce": nonce,
+        }
+    )
+    signed_txn = w3.eth.account.sign_transaction(
+        deploy_tx,
+        private_key=cfg["el"]["funder"]["private_key"],
+    )
+    w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+    tx_receipt = w3.eth.wait_for_transaction_receipt(signed_txn.hash)
+
+    logger.info(
+        f"Contract from '{foundry_json_path}' was published at address '{tx_receipt['contractAddress']}' [block: {tx_receipt['blockNumber']}]"
+    )
+
+    return tx_receipt["contractAddress"]
 
 def deploy_contract_onchain(
     cfg: dict, rpc: str, path: str, name: str, args: list = []

--- a/eth_possim/resources/ethereum_compiled_contracts/CalculateAndSendRewards.json
+++ b/eth_possim/resources/ethereum_compiled_contracts/CalculateAndSendRewards.json
@@ -1,0 +1,5149 @@
+{
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "withdrawalCredential",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "withdrawnAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "ownerFee",
+          "type": "uint256"
+        }
+      ],
+      "name": "CollectedReward",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "FEE_DENOMINATOR",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": {
+    "object": "0x61036461003a600b82828239805160001a60731461002d57634e487b7160e01b600052600060045260246000fd5b30600052607381538281f3fe73000000000000000000000000000000000000000030146080604052600436106100405760003560e01c8063d73792a914610045578063ea788f4314610067575b600080fd5b61004e61271081565b60405163ffffffff909116815260200160405180910390f35b81801561007357600080fd5b50610087610082366004610278565b610089565b005b600061271061009e63ffffffff8616476102dc565b6100a891906102f9565b905060006100b6824761031b565b9050811515806100c557508015155b61010e5760405162461bcd60e51b81526020600482015260156024820152744e6f7468696e6720746f206469737472696275746560581b60448201526064015b60405180910390fd5b604080516001600160a01b038581168252602082018490528616818301526060810184905290517fea26d65e718d9960bf3d074b264a29f878be92f11e3a4f1b5ab8e81038cc1fc09181900360800190a16040516001600160a01b0385169083156108fc029084906000818181858888f19350505050158015610195573d6000803e3d6000fd5b506000836001600160a01b03168260405160006040518083038185875af1925050503d80600081146101e3576040519150601f19603f3d011682016040523d82523d6000602084013e6101e8565b606091505b50509050806102545760405162461bcd60e51b815260206004820152603260248201527f4661696c656420746f2073656e64204574686572206261636b20746f207769746044820152711a191c985dd85b0818dc9959195b9d1a585b60721b6064820152608401610105565b505050505050565b80356001600160a01b038116811461027357600080fd5b919050565b60008060006060848603121561028d57600080fd5b833563ffffffff811681146102a157600080fd5b92506102af6020850161025c565b91506102bd6040850161025c565b90509250925092565b634e487b7160e01b600052601160045260246000fd5b80820281158282048414176102f3576102f36102c6565b92915050565b60008261031657634e487b7160e01b600052601260045260246000fd5b500490565b818103818111156102f3576102f36102c656fea2646970667358221220ee420c8c012ac5749453902735be24defd4356bb7223a63d894f1928266ba0f164736f6c63430008140033",
+    "sourceMap": "370:1280:19:-:0;;;;;;;;;;;;;;;-1:-1:-1;;;370:1280:19;;;;;;;;;;;;;;;;;",
+    "linkReferences": {}
+  },
+  "deployedBytecode": {
+    "object": "0x73000000000000000000000000000000000000000030146080604052600436106100405760003560e01c8063d73792a914610045578063ea788f4314610067575b600080fd5b61004e61271081565b60405163ffffffff909116815260200160405180910390f35b81801561007357600080fd5b50610087610082366004610278565b610089565b005b600061271061009e63ffffffff8616476102dc565b6100a891906102f9565b905060006100b6824761031b565b9050811515806100c557508015155b61010e5760405162461bcd60e51b81526020600482015260156024820152744e6f7468696e6720746f206469737472696275746560581b60448201526064015b60405180910390fd5b604080516001600160a01b038581168252602082018490528616818301526060810184905290517fea26d65e718d9960bf3d074b264a29f878be92f11e3a4f1b5ab8e81038cc1fc09181900360800190a16040516001600160a01b0385169083156108fc029084906000818181858888f19350505050158015610195573d6000803e3d6000fd5b506000836001600160a01b03168260405160006040518083038185875af1925050503d80600081146101e3576040519150601f19603f3d011682016040523d82523d6000602084013e6101e8565b606091505b50509050806102545760405162461bcd60e51b815260206004820152603260248201527f4661696c656420746f2073656e64204574686572206261636b20746f207769746044820152711a191c985dd85b0818dc9959195b9d1a585b60721b6064820152608401610105565b505050505050565b80356001600160a01b038116811461027357600080fd5b919050565b60008060006060848603121561028d57600080fd5b833563ffffffff811681146102a157600080fd5b92506102af6020850161025c565b91506102bd6040850161025c565b90509250925092565b634e487b7160e01b600052601160045260246000fd5b80820281158282048414176102f3576102f36102c6565b92915050565b60008261031657634e487b7160e01b600052601260045260246000fd5b500490565b818103818111156102f3576102f36102c656fea2646970667358221220ee420c8c012ac5749453902735be24defd4356bb7223a63d894f1928266ba0f164736f6c63430008140033",
+    "sourceMap": "370:1280:19:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;499:46;;540:5;499:46;;;;;196:10:21;184:23;;;166:42;;154:2;139:18;499:46:19;;;;;;;705:943;;;;;;;;;;-1:-1:-1;705:943:19;;;;;:::i;:::-;;:::i;:::-;;;844:19;540:5;867:36;866:68;867:36;;:21;:36;:::i;:::-;866:68;;;;:::i;:::-;844:90;-1:-1:-1;944:22:19;969:35;844:90;969:21;:35;:::i;:::-;944:60;-1:-1:-1;1035:16:19;;;;:39;;-1:-1:-1;1055:19:19;;;1035:39;1014:107;;;;-1:-1:-1;;;1014:107:19;;1688:2:21;1014:107:19;;;1670:21:21;1727:2;1707:18;;;1700:30;-1:-1:-1;;;1746:18:21;;;1739:51;1807:18;;1014:107:19;;;;;;;;;1136:131;;;-1:-1:-1;;;;;2123:15:21;;;2105:34;;2170:2;2155:18;;2148:34;;;2218:15;;2198:18;;;2191:43;2265:2;2250:18;;2243:34;;;1136:131:19;;;;;;;2054:3:21;1136:131:19;;;1419:36;;-1:-1:-1;;;;;1419:23:19;;;:36;;;;;1443:11;;1419:36;;;;1443:11;1419:23;:36;;;;;;;;;;;;;;;;;;;;;1466:9;1489:20;-1:-1:-1;;;;;1481:34:19;1536:14;1481:83;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1465:99;;;1582:4;1574:67;;;;-1:-1:-1;;;1574:67:19;;2700:2:21;1574:67:19;;;2682:21:21;2739:2;2719:18;;;2712:30;2778:34;2758:18;;;2751:62;-1:-1:-1;;;2829:18:21;;;2822:48;2887:19;;1574:67:19;2498:414:21;1574:67:19;834:814;;;705:943;;;:::o;219:173:21:-;287:20;;-1:-1:-1;;;;;336:31:21;;326:42;;316:70;;382:1;379;372:12;316:70;219:173;;;:::o;397:424::-;473:6;481;489;542:2;530:9;521:7;517:23;513:32;510:52;;;558:1;555;548:12;510:52;597:9;584:23;647:10;640:5;636:22;629:5;626:33;616:61;;673:1;670;663:12;616:61;696:5;-1:-1:-1;720:38:21;754:2;739:18;;720:38;:::i;:::-;710:48;;777:38;811:2;800:9;796:18;777:38;:::i;:::-;767:48;;397:424;;;;;:::o;826:127::-;887:10;882:3;878:20;875:1;868:31;918:4;915:1;908:15;942:4;939:1;932:15;958:168;1031:9;;;1062;;1079:15;;;1073:22;;1059:37;1049:71;;1100:18;;:::i;:::-;958:168;;;;:::o;1131:217::-;1171:1;1197;1187:132;;1241:10;1236:3;1232:20;1229:1;1222:31;1276:4;1273:1;1266:15;1304:4;1301:1;1294:15;1187:132;-1:-1:-1;1333:9:21;;1131:217::o;1353:128::-;1420:9;;;1441:11;;;1438:37;;;1455:18;;:::i",
+    "linkReferences": {}
+  },
+  "methodIdentifiers": {
+    "FEE_DENOMINATOR()": "d73792a9",
+    "calculateRewards(uint32,address,address)": "ea788f43"
+  },
+  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.20+commit.a1b79de6\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"withdrawalCredential\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"withdrawnAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"ownerFee\",\"type\":\"uint256\"}],\"name\":\"CollectedReward\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"FEE_DENOMINATOR\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/FeeRewardsManager.sol\":\"CalculateAndSendRewards\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":@openzeppelin/=lib/openzeppelin-contracts/\",\":ds-test/=lib/openzeppelin-contracts/lib/forge-std/lib/ds-test/src/\",\":erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/\",\":forge-std/=lib/openzeppelin-contracts/lib/forge-std/src/\",\":openzeppelin-contracts/=lib/openzeppelin-contracts/\",\"lib/openzeppelin-contracts:openzeppelin/=lib/openzeppelin-contracts/contracts/\"]},\"sources\":{\"lib/openzeppelin-contracts/contracts/access/Ownable.sol\":{\"keccak256\":\"0xba43b97fba0d32eb4254f6a5a297b39a19a247082a02d6e69349e071e2946218\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://fc980984badf3984b6303b377711220e067722bbd6a135b24669ff5069ef9f32\",\"dweb:/ipfs/QmPHXMSXj99XjSVM21YsY6aNtLLjLVXDbyN76J5HQYvvrz\"]},\"lib/openzeppelin-contracts/contracts/utils/Context.sol\":{\"keccak256\":\"0xe2e337e6dde9ef6b680e07338c493ebea1b5fd09b43424112868e9cc1706bca7\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6df0ddf21ce9f58271bdfaa85cde98b200ef242a05a3f85c2bc10a8294800a92\",\"dweb:/ipfs/QmRK2Y5Yc6BK7tGKkgsgn3aJEQGi5aakeSPZvS65PV8Xp3\"]},\"src/FeeRewardsManager.sol\":{\"keccak256\":\"0xee7707562ed88509b24a4afdb11a67e249e370a3cdcaadb4ec07f84e03ed7fee\",\"license\":\"BSD-3-Clause\",\"urls\":[\"bzz-raw://919c541bdc389cb848285b2dea3ae95530b979b4cc38464b7cbbb27a6de72b54\",\"dweb:/ipfs/QmcBL1oHeRKRdrmh8FYBbKkRjAMpgZjyCR46V1yazkLaL4\"]}},\"version\":1}",
+  "metadata": {
+    "compiler": {
+      "version": "0.8.20+commit.a1b79de6"
+    },
+    "language": "Solidity",
+    "output": {
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "withdrawalCredential",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "withdrawnAmount",
+              "type": "uint256",
+              "indexed": false
+            },
+            {
+              "internalType": "address",
+              "name": "owner",
+              "type": "address",
+              "indexed": false
+            },
+            {
+              "internalType": "uint256",
+              "name": "ownerFee",
+              "type": "uint256",
+              "indexed": false
+            }
+          ],
+          "type": "event",
+          "name": "CollectedReward",
+          "anonymous": false
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "FEE_DENOMINATOR",
+          "outputs": [
+            {
+              "internalType": "uint32",
+              "name": "",
+              "type": "uint32"
+            }
+          ]
+        }
+      ],
+      "devdoc": {
+        "kind": "dev",
+        "methods": {},
+        "version": 1
+      },
+      "userdoc": {
+        "kind": "user",
+        "methods": {},
+        "version": 1
+      }
+    },
+    "settings": {
+      "remappings": [
+        "@openzeppelin/=lib/openzeppelin-contracts/",
+        "ds-test/=lib/openzeppelin-contracts/lib/forge-std/lib/ds-test/src/",
+        "erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/",
+        "forge-std/=lib/openzeppelin-contracts/lib/forge-std/src/",
+        "openzeppelin-contracts/=lib/openzeppelin-contracts/",
+        "lib/openzeppelin-contracts:openzeppelin/=lib/openzeppelin-contracts/contracts/"
+      ],
+      "optimizer": {
+        "enabled": true,
+        "runs": 200
+      },
+      "metadata": {
+        "bytecodeHash": "ipfs"
+      },
+      "compilationTarget": {
+        "src/FeeRewardsManager.sol": "CalculateAndSendRewards"
+      },
+      "libraries": {}
+    },
+    "sources": {
+      "lib/openzeppelin-contracts/contracts/access/Ownable.sol": {
+        "keccak256": "0xba43b97fba0d32eb4254f6a5a297b39a19a247082a02d6e69349e071e2946218",
+        "urls": [
+          "bzz-raw://fc980984badf3984b6303b377711220e067722bbd6a135b24669ff5069ef9f32",
+          "dweb:/ipfs/QmPHXMSXj99XjSVM21YsY6aNtLLjLVXDbyN76J5HQYvvrz"
+        ],
+        "license": "MIT"
+      },
+      "lib/openzeppelin-contracts/contracts/utils/Context.sol": {
+        "keccak256": "0xe2e337e6dde9ef6b680e07338c493ebea1b5fd09b43424112868e9cc1706bca7",
+        "urls": [
+          "bzz-raw://6df0ddf21ce9f58271bdfaa85cde98b200ef242a05a3f85c2bc10a8294800a92",
+          "dweb:/ipfs/QmRK2Y5Yc6BK7tGKkgsgn3aJEQGi5aakeSPZvS65PV8Xp3"
+        ],
+        "license": "MIT"
+      },
+      "src/FeeRewardsManager.sol": {
+        "keccak256": "0xee7707562ed88509b24a4afdb11a67e249e370a3cdcaadb4ec07f84e03ed7fee",
+        "urls": [
+          "bzz-raw://919c541bdc389cb848285b2dea3ae95530b979b4cc38464b7cbbb27a6de72b54",
+          "dweb:/ipfs/QmcBL1oHeRKRdrmh8FYBbKkRjAMpgZjyCR46V1yazkLaL4"
+        ],
+        "license": "BSD-3-Clause"
+      }
+    },
+    "version": 1
+  },
+  "ast": {
+    "absolutePath": "src/FeeRewardsManager.sol",
+    "id": 28869,
+    "exportedSymbols": {
+      "CalculateAndSendRewards": [
+        28588
+      ],
+      "Context": [
+        134
+      ],
+      "FeeRewardsManager": [
+        28868
+      ],
+      "Ownable": [
+        112
+      ],
+      "RewardsCollector": [
+        28650
+      ]
+    },
+    "nodeType": "SourceUnit",
+    "src": "41:5509:19",
+    "nodes": [
+      {
+        "id": 28497,
+        "nodeType": "PragmaDirective",
+        "src": "41:24:19",
+        "nodes": [],
+        "literals": [
+          "solidity",
+          "^",
+          "0.8",
+          ".13"
+        ]
+      },
+      {
+        "id": 28498,
+        "nodeType": "ImportDirective",
+        "src": "67:52:19",
+        "nodes": [],
+        "absolutePath": "lib/openzeppelin-contracts/contracts/access/Ownable.sol",
+        "file": "@openzeppelin/contracts/access/Ownable.sol",
+        "nameLocation": "-1:-1:-1",
+        "scope": 28869,
+        "sourceUnit": 113,
+        "symbolAliases": [],
+        "unitAlias": ""
+      },
+      {
+        "id": 28588,
+        "nodeType": "ContractDefinition",
+        "src": "370:1280:19",
+        "nodes": [
+          {
+            "id": 28501,
+            "nodeType": "VariableDeclaration",
+            "src": "499:46:19",
+            "nodes": [],
+            "constant": true,
+            "functionSelector": "d73792a9",
+            "mutability": "constant",
+            "name": "FEE_DENOMINATOR",
+            "nameLocation": "522:15:19",
+            "scope": 28588,
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_uint32",
+              "typeString": "uint32"
+            },
+            "typeName": {
+              "id": 28499,
+              "name": "uint32",
+              "nodeType": "ElementaryTypeName",
+              "src": "499:6:19",
+              "typeDescriptions": {
+                "typeIdentifier": "t_uint32",
+                "typeString": "uint32"
+              }
+            },
+            "value": {
+              "hexValue": "3130303030",
+              "id": 28500,
+              "isConstant": false,
+              "isLValue": false,
+              "isPure": true,
+              "kind": "number",
+              "lValueRequested": false,
+              "nodeType": "Literal",
+              "src": "540:5:19",
+              "typeDescriptions": {
+                "typeIdentifier": "t_rational_10000_by_1",
+                "typeString": "int_const 10000"
+              },
+              "value": "10000"
+            },
+            "visibility": "public"
+          },
+          {
+            "id": 28511,
+            "nodeType": "EventDefinition",
+            "src": "551:148:19",
+            "nodes": [],
+            "anonymous": false,
+            "eventSelector": "ea26d65e718d9960bf3d074b264a29f878be92f11e3a4f1b5ab8e81038cc1fc0",
+            "name": "CollectedReward",
+            "nameLocation": "557:15:19",
+            "parameters": {
+              "id": 28510,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28503,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "withdrawalCredential",
+                  "nameLocation": "590:20:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28511,
+                  "src": "582:28:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28502,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "582:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 28505,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "withdrawnAmount",
+                  "nameLocation": "628:15:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28511,
+                  "src": "620:23:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 28504,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "620:7:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 28507,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "owner",
+                  "nameLocation": "661:5:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28511,
+                  "src": "653:13:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28506,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "653:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 28509,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "ownerFee",
+                  "nameLocation": "684:8:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28511,
+                  "src": "676:16:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  },
+                  "typeName": {
+                    "id": 28508,
+                    "name": "uint256",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "676:7:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "572:126:19"
+            }
+          },
+          {
+            "id": 28587,
+            "nodeType": "FunctionDefinition",
+            "src": "705:943:19",
+            "nodes": [],
+            "body": {
+              "id": 28586,
+              "nodeType": "Block",
+              "src": "834:814:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "assignments": [
+                    28521
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 28521,
+                      "mutability": "mutable",
+                      "name": "ownerAmount",
+                      "nameLocation": "852:11:19",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 28586,
+                      "src": "844:19:19",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      },
+                      "typeName": {
+                        "id": 28520,
+                        "name": "uint256",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "844:7:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 28532,
+                  "initialValue": {
+                    "commonType": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "id": 28531,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftExpression": {
+                      "components": [
+                        {
+                          "commonType": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          "id": 28528,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "leftExpression": {
+                            "expression": {
+                              "arguments": [
+                                {
+                                  "id": 28524,
+                                  "name": "this",
+                                  "nodeType": "Identifier",
+                                  "overloadedDeclarations": [],
+                                  "referencedDeclaration": -28,
+                                  "src": "875:4:19",
+                                  "typeDescriptions": {
+                                    "typeIdentifier": "t_contract$_CalculateAndSendRewards_$28588",
+                                    "typeString": "library CalculateAndSendRewards"
+                                  }
+                                }
+                              ],
+                              "expression": {
+                                "argumentTypes": [
+                                  {
+                                    "typeIdentifier": "t_contract$_CalculateAndSendRewards_$28588",
+                                    "typeString": "library CalculateAndSendRewards"
+                                  }
+                                ],
+                                "id": 28523,
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": true,
+                                "lValueRequested": false,
+                                "nodeType": "ElementaryTypeNameExpression",
+                                "src": "867:7:19",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_type$_t_address_$",
+                                  "typeString": "type(address)"
+                                },
+                                "typeName": {
+                                  "id": 28522,
+                                  "name": "address",
+                                  "nodeType": "ElementaryTypeName",
+                                  "src": "867:7:19",
+                                  "typeDescriptions": {}
+                                }
+                              },
+                              "id": 28525,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "kind": "typeConversion",
+                              "lValueRequested": false,
+                              "nameLocations": [],
+                              "names": [],
+                              "nodeType": "FunctionCall",
+                              "src": "867:13:19",
+                              "tryCall": false,
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
+                            "id": 28526,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "memberLocation": "881:7:19",
+                            "memberName": "balance",
+                            "nodeType": "MemberAccess",
+                            "src": "867:21:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          },
+                          "nodeType": "BinaryOperation",
+                          "operator": "*",
+                          "rightExpression": {
+                            "id": 28527,
+                            "name": "feeNominator",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 28513,
+                            "src": "891:12:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint32",
+                              "typeString": "uint32"
+                            }
+                          },
+                          "src": "867:36:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        }
+                      ],
+                      "id": 28529,
+                      "isConstant": false,
+                      "isInlineArray": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "nodeType": "TupleExpression",
+                      "src": "866:38:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "nodeType": "BinaryOperation",
+                    "operator": "/",
+                    "rightExpression": {
+                      "id": 28530,
+                      "name": "FEE_DENOMINATOR",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28501,
+                      "src": "919:15:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "src": "866:68:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "844:90:19"
+                },
+                {
+                  "assignments": [
+                    28534
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 28534,
+                      "mutability": "mutable",
+                      "name": "returnedAmount",
+                      "nameLocation": "952:14:19",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 28586,
+                      "src": "944:22:19",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      },
+                      "typeName": {
+                        "id": 28533,
+                        "name": "uint256",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "944:7:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 28542,
+                  "initialValue": {
+                    "commonType": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "id": 28541,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftExpression": {
+                      "expression": {
+                        "arguments": [
+                          {
+                            "id": 28537,
+                            "name": "this",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": -28,
+                            "src": "977:4:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_contract$_CalculateAndSendRewards_$28588",
+                              "typeString": "library CalculateAndSendRewards"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_contract$_CalculateAndSendRewards_$28588",
+                              "typeString": "library CalculateAndSendRewards"
+                            }
+                          ],
+                          "id": 28536,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "lValueRequested": false,
+                          "nodeType": "ElementaryTypeNameExpression",
+                          "src": "969:7:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_type$_t_address_$",
+                            "typeString": "type(address)"
+                          },
+                          "typeName": {
+                            "id": 28535,
+                            "name": "address",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "969:7:19",
+                            "typeDescriptions": {}
+                          }
+                        },
+                        "id": 28538,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "kind": "typeConversion",
+                        "lValueRequested": false,
+                        "nameLocations": [],
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "969:13:19",
+                        "tryCall": false,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "id": 28539,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "memberLocation": "983:7:19",
+                      "memberName": "balance",
+                      "nodeType": "MemberAccess",
+                      "src": "969:21:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "nodeType": "BinaryOperation",
+                    "operator": "-",
+                    "rightExpression": {
+                      "id": 28540,
+                      "name": "ownerAmount",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28521,
+                      "src": "993:11:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "src": "969:35:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "944:60:19"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        "id": 28550,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "commonType": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          "id": 28546,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "leftExpression": {
+                            "id": 28544,
+                            "name": "ownerAmount",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 28521,
+                            "src": "1035:11:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          },
+                          "nodeType": "BinaryOperation",
+                          "operator": "!=",
+                          "rightExpression": {
+                            "hexValue": "30",
+                            "id": 28545,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "kind": "number",
+                            "lValueRequested": false,
+                            "nodeType": "Literal",
+                            "src": "1050:1:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_rational_0_by_1",
+                              "typeString": "int_const 0"
+                            },
+                            "value": "0"
+                          },
+                          "src": "1035:16:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "||",
+                        "rightExpression": {
+                          "commonType": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          },
+                          "id": 28549,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "leftExpression": {
+                            "id": 28547,
+                            "name": "returnedAmount",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 28534,
+                            "src": "1055:14:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          },
+                          "nodeType": "BinaryOperation",
+                          "operator": "!=",
+                          "rightExpression": {
+                            "hexValue": "30",
+                            "id": 28548,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "kind": "number",
+                            "lValueRequested": false,
+                            "nodeType": "Literal",
+                            "src": "1073:1:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_rational_0_by_1",
+                              "typeString": "int_const 0"
+                            },
+                            "value": "0"
+                          },
+                          "src": "1055:19:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bool",
+                            "typeString": "bool"
+                          }
+                        },
+                        "src": "1035:39:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "4e6f7468696e6720746f2064697374726962757465",
+                        "id": 28551,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "1088:23:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_d842f201acf40e4a9c5acce2e04563f7270e91457322da48af841f8dba899054",
+                          "typeString": "literal_string \"Nothing to distribute\""
+                        },
+                        "value": "Nothing to distribute"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_d842f201acf40e4a9c5acce2e04563f7270e91457322da48af841f8dba899054",
+                          "typeString": "literal_string \"Nothing to distribute\""
+                        }
+                      ],
+                      "id": 28543,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        -18,
+                        -18
+                      ],
+                      "referencedDeclaration": -18,
+                      "src": "1014:7:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 28552,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1014:107:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 28553,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1014:107:19"
+                },
+                {
+                  "eventCall": {
+                    "arguments": [
+                      {
+                        "id": 28555,
+                        "name": "withdrawalCredential",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28517,
+                        "src": "1165:20:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 28556,
+                        "name": "returnedAmount",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28534,
+                        "src": "1199:14:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      },
+                      {
+                        "id": 28557,
+                        "name": "owner",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28515,
+                        "src": "1227:5:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 28558,
+                        "name": "ownerAmount",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28521,
+                        "src": "1246:11:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        },
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "id": 28554,
+                      "name": "CollectedReward",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28511,
+                      "src": "1136:15:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_address_$_t_uint256_$returns$__$",
+                        "typeString": "function (address,uint256,address,uint256)"
+                      }
+                    },
+                    "id": 28559,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1136:131:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 28560,
+                  "nodeType": "EmitStatement",
+                  "src": "1131:136:19"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "id": 28566,
+                        "name": "ownerAmount",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28521,
+                        "src": "1443:11:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "expression": {
+                        "arguments": [
+                          {
+                            "id": 28563,
+                            "name": "owner",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 28515,
+                            "src": "1427:5:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_address",
+                              "typeString": "address"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_address",
+                              "typeString": "address"
+                            }
+                          ],
+                          "id": 28562,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "lValueRequested": false,
+                          "nodeType": "ElementaryTypeNameExpression",
+                          "src": "1419:8:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_type$_t_address_payable_$",
+                            "typeString": "type(address payable)"
+                          },
+                          "typeName": {
+                            "id": 28561,
+                            "name": "address",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "1419:8:19",
+                            "stateMutability": "payable",
+                            "typeDescriptions": {}
+                          }
+                        },
+                        "id": 28564,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "kind": "typeConversion",
+                        "lValueRequested": false,
+                        "nameLocations": [],
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "1419:14:19",
+                        "tryCall": false,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address_payable",
+                          "typeString": "address payable"
+                        }
+                      },
+                      "id": 28565,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "memberLocation": "1434:8:19",
+                      "memberName": "transfer",
+                      "nodeType": "MemberAccess",
+                      "src": "1419:23:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_transfer_nonpayable$_t_uint256_$returns$__$",
+                        "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 28567,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1419:36:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 28568,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1419:36:19"
+                },
+                {
+                  "assignments": [
+                    28570,
+                    null
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 28570,
+                      "mutability": "mutable",
+                      "name": "sent",
+                      "nameLocation": "1471:4:19",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 28586,
+                      "src": "1466:9:19",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bool",
+                        "typeString": "bool"
+                      },
+                      "typeName": {
+                        "id": 28569,
+                        "name": "bool",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "1466:4:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      "visibility": "internal"
+                    },
+                    null
+                  ],
+                  "id": 28580,
+                  "initialValue": {
+                    "arguments": [
+                      {
+                        "hexValue": "",
+                        "id": 28578,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "1561:2:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+                          "typeString": "literal_string \"\""
+                        },
+                        "value": ""
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_stringliteral_c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+                          "typeString": "literal_string \"\""
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_stringliteral_c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+                            "typeString": "literal_string \"\""
+                          }
+                        ],
+                        "expression": {
+                          "arguments": [
+                            {
+                              "id": 28573,
+                              "name": "withdrawalCredential",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 28517,
+                              "src": "1489:20:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            ],
+                            "id": 28572,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "1481:8:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_address_payable_$",
+                              "typeString": "type(address payable)"
+                            },
+                            "typeName": {
+                              "id": 28571,
+                              "name": "address",
+                              "nodeType": "ElementaryTypeName",
+                              "src": "1481:8:19",
+                              "stateMutability": "payable",
+                              "typeDescriptions": {}
+                            }
+                          },
+                          "id": 28574,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "nameLocations": [],
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "1481:29:19",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address_payable",
+                            "typeString": "address payable"
+                          }
+                        },
+                        "id": 28575,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "memberLocation": "1511:4:19",
+                        "memberName": "call",
+                        "nodeType": "MemberAccess",
+                        "src": "1481:34:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_function_barecall_payable$_t_bytes_memory_ptr_$returns$_t_bool_$_t_bytes_memory_ptr_$",
+                          "typeString": "function (bytes memory) payable returns (bool,bytes memory)"
+                        }
+                      },
+                      "id": 28577,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "names": [
+                        "value"
+                      ],
+                      "nodeType": "FunctionCallOptions",
+                      "options": [
+                        {
+                          "id": 28576,
+                          "name": "returnedAmount",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 28534,
+                          "src": "1536:14:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint256",
+                            "typeString": "uint256"
+                          }
+                        }
+                      ],
+                      "src": "1481:79:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_barecall_payable$_t_bytes_memory_ptr_$returns$_t_bool_$_t_bytes_memory_ptr_$value",
+                        "typeString": "function (bytes memory) payable returns (bool,bytes memory)"
+                      }
+                    },
+                    "id": 28579,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1481:83:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$_t_bool_$_t_bytes_memory_ptr_$",
+                      "typeString": "tuple(bool,bytes memory)"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "1465:99:19"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "id": 28582,
+                        "name": "sent",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28570,
+                        "src": "1582:4:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "4661696c656420746f2073656e64204574686572206261636b20746f207769746864726177616c2063726564656e7469616c",
+                        "id": 28583,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "1588:52:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_6ccf786fc3618692ee3b7a0f19c9a459b50c544b1291a2feb85a687148f1638e",
+                          "typeString": "literal_string \"Failed to send Ether back to withdrawal credential\""
+                        },
+                        "value": "Failed to send Ether back to withdrawal credential"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_6ccf786fc3618692ee3b7a0f19c9a459b50c544b1291a2feb85a687148f1638e",
+                          "typeString": "literal_string \"Failed to send Ether back to withdrawal credential\""
+                        }
+                      ],
+                      "id": 28581,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        -18,
+                        -18
+                      ],
+                      "referencedDeclaration": -18,
+                      "src": "1574:7:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 28584,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "1574:67:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 28585,
+                  "nodeType": "ExpressionStatement",
+                  "src": "1574:67:19"
+                }
+              ]
+            },
+            "functionSelector": "ea788f43",
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "calculateRewards",
+            "nameLocation": "714:16:19",
+            "parameters": {
+              "id": 28518,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28513,
+                  "mutability": "mutable",
+                  "name": "feeNominator",
+                  "nameLocation": "747:12:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28587,
+                  "src": "740:19:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint32",
+                    "typeString": "uint32"
+                  },
+                  "typeName": {
+                    "id": 28512,
+                    "name": "uint32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "740:6:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 28515,
+                  "mutability": "mutable",
+                  "name": "owner",
+                  "nameLocation": "777:5:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28587,
+                  "src": "769:13:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28514,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "769:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 28517,
+                  "mutability": "mutable",
+                  "name": "withdrawalCredential",
+                  "nameLocation": "800:20:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28587,
+                  "src": "792:28:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28516,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "792:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "730:96:19"
+            },
+            "returnParameters": {
+              "id": 28519,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "834:0:19"
+            },
+            "scope": 28588,
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          }
+        ],
+        "abstract": false,
+        "baseContracts": [],
+        "canonicalName": "CalculateAndSendRewards",
+        "contractDependencies": [],
+        "contractKind": "library",
+        "fullyImplemented": true,
+        "linearizedBaseContracts": [
+          28588
+        ],
+        "name": "CalculateAndSendRewards",
+        "nameLocation": "378:23:19",
+        "scope": 28869,
+        "usedErrors": [],
+        "usedEvents": [
+          28511
+        ]
+      },
+      {
+        "id": 28650,
+        "nodeType": "ContractDefinition",
+        "src": "1652:1234:19",
+        "nodes": [
+          {
+            "id": 28590,
+            "nodeType": "VariableDeclaration",
+            "src": "1738:35:19",
+            "nodes": [],
+            "constant": false,
+            "functionSelector": "83059303",
+            "mutability": "mutable",
+            "name": "withdrawalCredential",
+            "nameLocation": "1753:20:19",
+            "scope": 28650,
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_address",
+              "typeString": "address"
+            },
+            "typeName": {
+              "id": 28589,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "1738:7:19",
+              "stateMutability": "nonpayable",
+              "typeDescriptions": {
+                "typeIdentifier": "t_address",
+                "typeString": "address"
+              }
+            },
+            "visibility": "public"
+          },
+          {
+            "id": 28592,
+            "nodeType": "VariableDeclaration",
+            "src": "1804:26:19",
+            "nodes": [],
+            "constant": false,
+            "functionSelector": "e86dea4a",
+            "mutability": "mutable",
+            "name": "feeNumerator",
+            "nameLocation": "1818:12:19",
+            "scope": 28650,
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_uint32",
+              "typeString": "uint32"
+            },
+            "typeName": {
+              "id": 28591,
+              "name": "uint32",
+              "nodeType": "ElementaryTypeName",
+              "src": "1804:6:19",
+              "typeDescriptions": {
+                "typeIdentifier": "t_uint32",
+                "typeString": "uint32"
+              }
+            },
+            "visibility": "public"
+          },
+          {
+            "id": 28594,
+            "nodeType": "VariableDeclaration",
+            "src": "2124:29:19",
+            "nodes": [],
+            "constant": false,
+            "functionSelector": "230b9da3",
+            "mutability": "mutable",
+            "name": "parentContract",
+            "nameLocation": "2139:14:19",
+            "scope": 28650,
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_address",
+              "typeString": "address"
+            },
+            "typeName": {
+              "id": 28593,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "2124:7:19",
+              "stateMutability": "nonpayable",
+              "typeDescriptions": {
+                "typeIdentifier": "t_address",
+                "typeString": "address"
+              }
+            },
+            "visibility": "public"
+          },
+          {
+            "id": 28598,
+            "nodeType": "FunctionDefinition",
+            "src": "2206:29:19",
+            "nodes": [],
+            "body": {
+              "id": 28597,
+              "nodeType": "Block",
+              "src": "2233:2:19",
+              "nodes": [],
+              "statements": []
+            },
+            "implemented": true,
+            "kind": "receive",
+            "modifiers": [],
+            "name": "",
+            "nameLocation": "-1:-1:-1",
+            "parameters": {
+              "id": 28595,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2213:2:19"
+            },
+            "returnParameters": {
+              "id": 28596,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2233:0:19"
+            },
+            "scope": 28650,
+            "stateMutability": "payable",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "id": 28610,
+            "nodeType": "FunctionDefinition",
+            "src": "2241:196:19",
+            "nodes": [],
+            "body": {
+              "id": 28609,
+              "nodeType": "Block",
+              "src": "2282:155:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "id": 28604,
+                        "name": "feeNumerator",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28592,
+                        "src": "2346:12:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint32",
+                          "typeString": "uint32"
+                        }
+                      },
+                      {
+                        "id": 28605,
+                        "name": "parentContract",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28594,
+                        "src": "2372:14:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 28606,
+                        "name": "withdrawalCredential",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28590,
+                        "src": "2400:20:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint32",
+                          "typeString": "uint32"
+                        },
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      ],
+                      "expression": {
+                        "id": 28601,
+                        "name": "CalculateAndSendRewards",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28588,
+                        "src": "2292:23:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_contract$_CalculateAndSendRewards_$28588_$",
+                          "typeString": "type(library CalculateAndSendRewards)"
+                        }
+                      },
+                      "id": 28603,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "memberLocation": "2316:16:19",
+                      "memberName": "calculateRewards",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 28587,
+                      "src": "2292:40:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_delegatecall_nonpayable$_t_uint32_$_t_address_$_t_address_$returns$__$",
+                        "typeString": "function (uint32,address,address)"
+                      }
+                    },
+                    "id": 28607,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2292:138:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 28608,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2292:138:19"
+                }
+              ]
+            },
+            "functionSelector": "70bb45b3",
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "collectRewards",
+            "nameLocation": "2250:14:19",
+            "parameters": {
+              "id": 28599,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2264:2:19"
+            },
+            "returnParameters": {
+              "id": 28600,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2282:0:19"
+            },
+            "scope": 28650,
+            "stateMutability": "payable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "id": 28631,
+            "nodeType": "FunctionDefinition",
+            "src": "2443:201:19",
+            "nodes": [],
+            "body": {
+              "id": 28630,
+              "nodeType": "Block",
+              "src": "2508:136:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "expression": {
+                    "id": 28619,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "id": 28617,
+                      "name": "withdrawalCredential",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28590,
+                      "src": "2518:20:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "id": 28618,
+                      "name": "_withdrawalCredential",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28612,
+                      "src": "2541:21:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "src": "2518:44:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "id": 28620,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2518:44:19"
+                },
+                {
+                  "expression": {
+                    "id": 28623,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "id": 28621,
+                      "name": "feeNumerator",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28592,
+                      "src": "2572:12:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "id": 28622,
+                      "name": "_feeNumerator",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28614,
+                      "src": "2587:13:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "src": "2572:28:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "id": 28624,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2572:28:19"
+                },
+                {
+                  "expression": {
+                    "id": 28628,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "id": 28625,
+                      "name": "parentContract",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28594,
+                      "src": "2610:14:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "expression": {
+                        "id": 28626,
+                        "name": "msg",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": -15,
+                        "src": "2627:3:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_magic_message",
+                          "typeString": "msg"
+                        }
+                      },
+                      "id": 28627,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "memberLocation": "2631:6:19",
+                      "memberName": "sender",
+                      "nodeType": "MemberAccess",
+                      "src": "2627:10:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    "src": "2610:27:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "id": 28629,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2610:27:19"
+                }
+              ]
+            },
+            "implemented": true,
+            "kind": "constructor",
+            "modifiers": [],
+            "name": "",
+            "nameLocation": "-1:-1:-1",
+            "parameters": {
+              "id": 28615,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28612,
+                  "mutability": "mutable",
+                  "name": "_withdrawalCredential",
+                  "nameLocation": "2463:21:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28631,
+                  "src": "2455:29:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28611,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2455:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 28614,
+                  "mutability": "mutable",
+                  "name": "_feeNumerator",
+                  "nameLocation": "2493:13:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28631,
+                  "src": "2486:20:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint32",
+                    "typeString": "uint32"
+                  },
+                  "typeName": {
+                    "id": 28613,
+                    "name": "uint32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2486:6:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2454:53:19"
+            },
+            "returnParameters": {
+              "id": 28616,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2508:0:19"
+            },
+            "scope": 28650,
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "id": 28649,
+            "nodeType": "FunctionDefinition",
+            "src": "2650:234:19",
+            "nodes": [],
+            "body": {
+              "id": 28648,
+              "nodeType": "Block",
+              "src": "2710:174:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "commonType": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        "id": 28640,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "leftExpression": {
+                          "expression": {
+                            "id": 28637,
+                            "name": "msg",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": -15,
+                            "src": "2741:3:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_magic_message",
+                              "typeString": "msg"
+                            }
+                          },
+                          "id": 28638,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "memberLocation": "2745:6:19",
+                          "memberName": "sender",
+                          "nodeType": "MemberAccess",
+                          "src": "2741:10:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "nodeType": "BinaryOperation",
+                        "operator": "==",
+                        "rightExpression": {
+                          "id": 28639,
+                          "name": "parentContract",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 28594,
+                          "src": "2755:14:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "src": "2741:28:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        }
+                      },
+                      {
+                        "hexValue": "4368616e6765466565206e6f742063616c6c65642066726f6d20706172656e7420636f6e7472616374",
+                        "id": 28641,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "kind": "string",
+                        "lValueRequested": false,
+                        "nodeType": "Literal",
+                        "src": "2783:43:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_stringliteral_3ac16390d20fe80ce13231de77b89bac161e164e2dad6197662a09bda86b1722",
+                          "typeString": "literal_string \"ChangeFee not called from parent contract\""
+                        },
+                        "value": "ChangeFee not called from parent contract"
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bool",
+                          "typeString": "bool"
+                        },
+                        {
+                          "typeIdentifier": "t_stringliteral_3ac16390d20fe80ce13231de77b89bac161e164e2dad6197662a09bda86b1722",
+                          "typeString": "literal_string \"ChangeFee not called from parent contract\""
+                        }
+                      ],
+                      "id": 28636,
+                      "name": "require",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [
+                        -18,
+                        -18
+                      ],
+                      "referencedDeclaration": -18,
+                      "src": "2720:7:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                        "typeString": "function (bool,string memory) pure"
+                      }
+                    },
+                    "id": 28642,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "2720:116:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 28643,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2720:116:19"
+                },
+                {
+                  "expression": {
+                    "id": 28646,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "id": 28644,
+                      "name": "feeNumerator",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28592,
+                      "src": "2846:12:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "id": 28645,
+                      "name": "_newFeeNumerator",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28633,
+                      "src": "2861:16:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "src": "2846:31:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "id": 28647,
+                  "nodeType": "ExpressionStatement",
+                  "src": "2846:31:19"
+                }
+              ]
+            },
+            "functionSelector": "35c84277",
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "changeFeeNumerator",
+            "nameLocation": "2659:18:19",
+            "parameters": {
+              "id": 28634,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28633,
+                  "mutability": "mutable",
+                  "name": "_newFeeNumerator",
+                  "nameLocation": "2685:16:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28649,
+                  "src": "2678:23:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint32",
+                    "typeString": "uint32"
+                  },
+                  "typeName": {
+                    "id": 28632,
+                    "name": "uint32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2678:6:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2677:25:19"
+            },
+            "returnParameters": {
+              "id": 28635,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "2710:0:19"
+            },
+            "scope": 28650,
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          }
+        ],
+        "abstract": false,
+        "baseContracts": [],
+        "canonicalName": "RewardsCollector",
+        "contractDependencies": [],
+        "contractKind": "contract",
+        "fullyImplemented": true,
+        "linearizedBaseContracts": [
+          28650
+        ],
+        "name": "RewardsCollector",
+        "nameLocation": "1661:16:19",
+        "scope": 28869,
+        "usedErrors": [],
+        "usedEvents": []
+      },
+      {
+        "id": 28868,
+        "nodeType": "ContractDefinition",
+        "src": "2888:2661:19",
+        "nodes": [
+          {
+            "id": 28654,
+            "nodeType": "VariableDeclaration",
+            "src": "2932:33:19",
+            "nodes": [],
+            "constant": false,
+            "functionSelector": "af3f6f4d",
+            "mutability": "mutable",
+            "name": "defaultFeeNumerator",
+            "nameLocation": "2946:19:19",
+            "scope": 28868,
+            "stateVariable": true,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_uint32",
+              "typeString": "uint32"
+            },
+            "typeName": {
+              "id": 28653,
+              "name": "uint32",
+              "nodeType": "ElementaryTypeName",
+              "src": "2932:6:19",
+              "typeDescriptions": {
+                "typeIdentifier": "t_uint32",
+                "typeString": "uint32"
+              }
+            },
+            "visibility": "public"
+          },
+          {
+            "id": 28664,
+            "nodeType": "FunctionDefinition",
+            "src": "2972:100:19",
+            "nodes": [],
+            "body": {
+              "id": 28663,
+              "nodeType": "Block",
+              "src": "3013:59:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "expression": {
+                    "id": 28661,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "id": 28659,
+                      "name": "defaultFeeNumerator",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28654,
+                      "src": "3023:19:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "id": 28660,
+                      "name": "_defaultFeeNumerator",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28656,
+                      "src": "3045:20:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "src": "3023:42:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "id": 28662,
+                  "nodeType": "ExpressionStatement",
+                  "src": "3023:42:19"
+                }
+              ]
+            },
+            "implemented": true,
+            "kind": "constructor",
+            "modifiers": [],
+            "name": "",
+            "nameLocation": "-1:-1:-1",
+            "parameters": {
+              "id": 28657,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28656,
+                  "mutability": "mutable",
+                  "name": "_defaultFeeNumerator",
+                  "nameLocation": "2991:20:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28664,
+                  "src": "2984:27:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint32",
+                    "typeString": "uint32"
+                  },
+                  "typeName": {
+                    "id": 28655,
+                    "name": "uint32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "2984:6:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "2983:29:19"
+            },
+            "returnParameters": {
+              "id": 28658,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3013:0:19"
+            },
+            "scope": 28868,
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "id": 28670,
+            "nodeType": "EventDefinition",
+            "src": "3078:69:19",
+            "nodes": [],
+            "anonymous": false,
+            "eventSelector": "620dca0c9d04f7cea9d7f31e571d74acccd54c21dc8ff8855ec1d5a21733c26b",
+            "name": "ContractDeployed",
+            "nameLocation": "3084:16:19",
+            "parameters": {
+              "id": 28669,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28666,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "contractAddress",
+                  "nameLocation": "3109:15:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28670,
+                  "src": "3101:23:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28665,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3101:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 28668,
+                  "indexed": false,
+                  "mutability": "mutable",
+                  "name": "feeNumerator",
+                  "nameLocation": "3133:12:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28670,
+                  "src": "3126:19:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint32",
+                    "typeString": "uint32"
+                  },
+                  "typeName": {
+                    "id": 28667,
+                    "name": "uint32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3126:6:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3100:46:19"
+            }
+          },
+          {
+            "id": 28682,
+            "nodeType": "FunctionDefinition",
+            "src": "3153:123:19",
+            "nodes": [],
+            "body": {
+              "id": 28681,
+              "nodeType": "Block",
+              "src": "3221:55:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "expression": {
+                    "id": 28679,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "id": 28677,
+                      "name": "defaultFeeNumerator",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28654,
+                      "src": "3231:19:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "id": 28678,
+                      "name": "_newFeeNumerator",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28672,
+                      "src": "3253:16:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "src": "3231:38:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "id": 28680,
+                  "nodeType": "ExpressionStatement",
+                  "src": "3231:38:19"
+                }
+              ]
+            },
+            "functionSelector": "ef5828d0",
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [
+              {
+                "id": 28675,
+                "kind": "modifierInvocation",
+                "modifierName": {
+                  "id": 28674,
+                  "name": "onlyOwner",
+                  "nameLocations": [
+                    "3211:9:19"
+                  ],
+                  "nodeType": "IdentifierPath",
+                  "referencedDeclaration": 31,
+                  "src": "3211:9:19"
+                },
+                "nodeType": "ModifierInvocation",
+                "src": "3211:9:19"
+              }
+            ],
+            "name": "changeDefaultFee",
+            "nameLocation": "3162:16:19",
+            "parameters": {
+              "id": 28673,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28672,
+                  "mutability": "mutable",
+                  "name": "_newFeeNumerator",
+                  "nameLocation": "3186:16:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28682,
+                  "src": "3179:23:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint32",
+                    "typeString": "uint32"
+                  },
+                  "typeName": {
+                    "id": 28671,
+                    "name": "uint32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3179:6:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3178:25:19"
+            },
+            "returnParameters": {
+              "id": 28676,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "3221:0:19"
+            },
+            "scope": 28868,
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "id": 28727,
+            "nodeType": "FunctionDefinition",
+            "src": "3282:551:19",
+            "nodes": [],
+            "body": {
+              "id": 28726,
+              "nodeType": "Block",
+              "src": "3387:446:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "assignments": [
+                    28690
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 28690,
+                      "mutability": "mutable",
+                      "name": "withdrawalCredentialBytes",
+                      "nameLocation": "3405:25:19",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 28726,
+                      "src": "3397:33:19",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes32",
+                        "typeString": "bytes32"
+                      },
+                      "typeName": {
+                        "id": 28689,
+                        "name": "bytes32",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3397:7:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes32",
+                          "typeString": "bytes32"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 28701,
+                  "initialValue": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "arguments": [
+                              {
+                                "id": 28697,
+                                "name": "_withdrawalCredential",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 28684,
+                                "src": "3470:21:19",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              }
+                            ],
+                            "expression": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              ],
+                              "id": 28696,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "lValueRequested": false,
+                              "nodeType": "ElementaryTypeNameExpression",
+                              "src": "3462:7:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_type$_t_uint160_$",
+                                "typeString": "type(uint160)"
+                              },
+                              "typeName": {
+                                "id": 28695,
+                                "name": "uint160",
+                                "nodeType": "ElementaryTypeName",
+                                "src": "3462:7:19",
+                                "typeDescriptions": {}
+                              }
+                            },
+                            "id": 28698,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": false,
+                            "kind": "typeConversion",
+                            "lValueRequested": false,
+                            "nameLocations": [],
+                            "names": [],
+                            "nodeType": "FunctionCall",
+                            "src": "3462:30:19",
+                            "tryCall": false,
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint160",
+                              "typeString": "uint160"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_uint160",
+                              "typeString": "uint160"
+                            }
+                          ],
+                          "id": 28694,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "lValueRequested": false,
+                          "nodeType": "ElementaryTypeNameExpression",
+                          "src": "3454:7:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_type$_t_uint256_$",
+                            "typeString": "type(uint256)"
+                          },
+                          "typeName": {
+                            "id": 28693,
+                            "name": "uint256",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "3454:7:19",
+                            "typeDescriptions": {}
+                          }
+                        },
+                        "id": 28699,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "kind": "typeConversion",
+                        "lValueRequested": false,
+                        "nameLocations": [],
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "3454:39:19",
+                        "tryCall": false,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "id": 28692,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "lValueRequested": false,
+                      "nodeType": "ElementaryTypeNameExpression",
+                      "src": "3433:7:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_type$_t_bytes32_$",
+                        "typeString": "type(bytes32)"
+                      },
+                      "typeName": {
+                        "id": 28691,
+                        "name": "bytes32",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3433:7:19",
+                        "typeDescriptions": {}
+                      }
+                    },
+                    "id": 28700,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "typeConversion",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3433:70:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "3397:106:19"
+                },
+                {
+                  "assignments": [
+                    28703
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 28703,
+                      "mutability": "mutable",
+                      "name": "addr",
+                      "nameLocation": "3521:4:19",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 28726,
+                      "src": "3513:12:19",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      "typeName": {
+                        "id": 28702,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3513:7:19",
+                        "stateMutability": "nonpayable",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 28715,
+                  "initialValue": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "id": 28711,
+                            "name": "_withdrawalCredential",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 28684,
+                            "src": "3656:21:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_address",
+                              "typeString": "address"
+                            }
+                          },
+                          {
+                            "id": 28712,
+                            "name": "defaultFeeNumerator",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 28654,
+                            "src": "3695:19:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint32",
+                              "typeString": "uint32"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_address",
+                              "typeString": "address"
+                            },
+                            {
+                              "typeIdentifier": "t_uint32",
+                              "typeString": "uint32"
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              },
+                              {
+                                "typeIdentifier": "t_uint32",
+                                "typeString": "uint32"
+                              }
+                            ],
+                            "id": 28708,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "nodeType": "NewExpression",
+                            "src": "3585:20:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_function_creation_nonpayable$_t_address_$_t_uint32_$returns$_t_contract$_RewardsCollector_$28650_$",
+                              "typeString": "function (address,uint32) returns (contract RewardsCollector)"
+                            },
+                            "typeName": {
+                              "id": 28707,
+                              "nodeType": "UserDefinedTypeName",
+                              "pathNode": {
+                                "id": 28706,
+                                "name": "RewardsCollector",
+                                "nameLocations": [
+                                  "3589:16:19"
+                                ],
+                                "nodeType": "IdentifierPath",
+                                "referencedDeclaration": 28650,
+                                "src": "3589:16:19"
+                              },
+                              "referencedDeclaration": 28650,
+                              "src": "3589:16:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                                "typeString": "contract RewardsCollector"
+                              }
+                            }
+                          },
+                          "id": 28710,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "names": [
+                            "salt"
+                          ],
+                          "nodeType": "FunctionCallOptions",
+                          "options": [
+                            {
+                              "id": 28709,
+                              "name": "withdrawalCredentialBytes",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 28690,
+                              "src": "3612:25:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_bytes32",
+                                "typeString": "bytes32"
+                              }
+                            }
+                          ],
+                          "src": "3585:53:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_function_creation_nonpayable$_t_address_$_t_uint32_$returns$_t_contract$_RewardsCollector_$28650_$salt",
+                            "typeString": "function (address,uint32) returns (contract RewardsCollector)"
+                          }
+                        },
+                        "id": 28713,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "kind": "functionCall",
+                        "lValueRequested": false,
+                        "nameLocations": [],
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "3585:143:19",
+                        "tryCall": false,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                          "typeString": "contract RewardsCollector"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                          "typeString": "contract RewardsCollector"
+                        }
+                      ],
+                      "id": 28705,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "lValueRequested": false,
+                      "nodeType": "ElementaryTypeNameExpression",
+                      "src": "3528:7:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_type$_t_address_$",
+                        "typeString": "type(address)"
+                      },
+                      "typeName": {
+                        "id": 28704,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3528:7:19",
+                        "typeDescriptions": {}
+                      }
+                    },
+                    "id": 28714,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "typeConversion",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3528:210:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "3513:225:19"
+                },
+                {
+                  "eventCall": {
+                    "arguments": [
+                      {
+                        "id": 28717,
+                        "name": "addr",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28703,
+                        "src": "3770:4:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      },
+                      {
+                        "id": 28718,
+                        "name": "defaultFeeNumerator",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28654,
+                        "src": "3776:19:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint32",
+                          "typeString": "uint32"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        },
+                        {
+                          "typeIdentifier": "t_uint32",
+                          "typeString": "uint32"
+                        }
+                      ],
+                      "id": 28716,
+                      "name": "ContractDeployed",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28670,
+                      "src": "3753:16:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint32_$returns$__$",
+                        "typeString": "function (address,uint32)"
+                      }
+                    },
+                    "id": 28719,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3753:43:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 28720,
+                  "nodeType": "EmitStatement",
+                  "src": "3748:48:19"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "id": 28723,
+                        "name": "addr",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28703,
+                        "src": "3821:4:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_address",
+                          "typeString": "address"
+                        }
+                      ],
+                      "id": 28722,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "lValueRequested": false,
+                      "nodeType": "ElementaryTypeNameExpression",
+                      "src": "3813:8:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_type$_t_address_payable_$",
+                        "typeString": "type(address payable)"
+                      },
+                      "typeName": {
+                        "id": 28721,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "3813:8:19",
+                        "stateMutability": "payable",
+                        "typeDescriptions": {}
+                      }
+                    },
+                    "id": 28724,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "typeConversion",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "3813:13:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address_payable",
+                      "typeString": "address payable"
+                    }
+                  },
+                  "functionReturnParameters": 28688,
+                  "id": 28725,
+                  "nodeType": "Return",
+                  "src": "3806:20:19"
+                }
+              ]
+            },
+            "functionSelector": "673c949d",
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "createFeeContract",
+            "nameLocation": "3291:17:19",
+            "parameters": {
+              "id": 28685,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28684,
+                  "mutability": "mutable",
+                  "name": "_withdrawalCredential",
+                  "nameLocation": "3326:21:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28727,
+                  "src": "3318:29:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28683,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3318:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3308:45:19"
+            },
+            "returnParameters": {
+              "id": 28688,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28687,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nameLocation": "-1:-1:-1",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28727,
+                  "src": "3370:15:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address_payable",
+                    "typeString": "address payable"
+                  },
+                  "typeName": {
+                    "id": 28686,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "3370:15:19",
+                    "stateMutability": "payable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address_payable",
+                      "typeString": "address payable"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "3369:17:19"
+            },
+            "scope": 28868,
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "id": 28798,
+            "nodeType": "FunctionDefinition",
+            "src": "4203:713:19",
+            "nodes": [],
+            "body": {
+              "id": 28797,
+              "nodeType": "Block",
+              "src": "4313:603:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "assignments": [
+                    28735
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 28735,
+                      "mutability": "mutable",
+                      "name": "bytecode",
+                      "nameLocation": "4336:8:19",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 28797,
+                      "src": "4323:21:19",
+                      "stateVariable": false,
+                      "storageLocation": "memory",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes_memory_ptr",
+                        "typeString": "bytes"
+                      },
+                      "typeName": {
+                        "id": 28734,
+                        "name": "bytes",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "4323:5:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes_storage_ptr",
+                          "typeString": "bytes"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 28740,
+                  "initialValue": {
+                    "expression": {
+                      "arguments": [
+                        {
+                          "id": 28737,
+                          "name": "RewardsCollector",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 28650,
+                          "src": "4352:16:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_type$_t_contract$_RewardsCollector_$28650_$",
+                            "typeString": "type(contract RewardsCollector)"
+                          }
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_type$_t_contract$_RewardsCollector_$28650_$",
+                            "typeString": "type(contract RewardsCollector)"
+                          }
+                        ],
+                        "id": 28736,
+                        "name": "type",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": -27,
+                        "src": "4347:4:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_function_metatype_pure$__$returns$__$",
+                          "typeString": "function () pure"
+                        }
+                      },
+                      "id": 28738,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "functionCall",
+                      "lValueRequested": false,
+                      "nameLocations": [],
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "4347:22:19",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_magic_meta_type_t_contract$_RewardsCollector_$28650",
+                        "typeString": "type(contract RewardsCollector)"
+                      }
+                    },
+                    "id": 28739,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "lValueRequested": false,
+                    "memberLocation": "4370:12:19",
+                    "memberName": "creationCode",
+                    "nodeType": "MemberAccess",
+                    "src": "4347:35:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_memory_ptr",
+                      "typeString": "bytes memory"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "4323:59:19"
+                },
+                {
+                  "expression": {
+                    "id": 28751,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "id": 28741,
+                      "name": "bytecode",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28735,
+                      "src": "4392:8:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes_memory_ptr",
+                        "typeString": "bytes memory"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "arguments": [
+                        {
+                          "id": 28744,
+                          "name": "bytecode",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 28735,
+                          "src": "4433:8:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bytes_memory_ptr",
+                            "typeString": "bytes memory"
+                          }
+                        },
+                        {
+                          "arguments": [
+                            {
+                              "id": 28747,
+                              "name": "_withdrawalCredential",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 28729,
+                              "src": "4466:21:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              }
+                            },
+                            {
+                              "id": 28748,
+                              "name": "defaultFeeNumerator",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": 28654,
+                              "src": "4489:19:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_uint32",
+                                "typeString": "uint32"
+                              }
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                              },
+                              {
+                                "typeIdentifier": "t_uint32",
+                                "typeString": "uint32"
+                              }
+                            ],
+                            "expression": {
+                              "id": 28745,
+                              "name": "abi",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": -1,
+                              "src": "4455:3:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_magic_abi",
+                                "typeString": "abi"
+                              }
+                            },
+                            "id": 28746,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "memberLocation": "4459:6:19",
+                            "memberName": "encode",
+                            "nodeType": "MemberAccess",
+                            "src": "4455:10:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_function_abiencode_pure$__$returns$_t_bytes_memory_ptr_$",
+                              "typeString": "function () pure returns (bytes memory)"
+                            }
+                          },
+                          "id": 28749,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "kind": "functionCall",
+                          "lValueRequested": false,
+                          "nameLocations": [],
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "4455:54:19",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_bytes_memory_ptr",
+                            "typeString": "bytes memory"
+                          }
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_bytes_memory_ptr",
+                            "typeString": "bytes memory"
+                          },
+                          {
+                            "typeIdentifier": "t_bytes_memory_ptr",
+                            "typeString": "bytes memory"
+                          }
+                        ],
+                        "expression": {
+                          "id": 28742,
+                          "name": "abi",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": -1,
+                          "src": "4403:3:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_magic_abi",
+                            "typeString": "abi"
+                          }
+                        },
+                        "id": 28743,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "memberLocation": "4407:12:19",
+                        "memberName": "encodePacked",
+                        "nodeType": "MemberAccess",
+                        "src": "4403:16:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_function_abiencodepacked_pure$__$returns$_t_bytes_memory_ptr_$",
+                          "typeString": "function () pure returns (bytes memory)"
+                        }
+                      },
+                      "id": 28750,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "kind": "functionCall",
+                      "lValueRequested": false,
+                      "nameLocations": [],
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "4403:116:19",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes_memory_ptr",
+                        "typeString": "bytes memory"
+                      }
+                    },
+                    "src": "4392:127:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes_memory_ptr",
+                      "typeString": "bytes memory"
+                    }
+                  },
+                  "id": 28752,
+                  "nodeType": "ExpressionStatement",
+                  "src": "4392:127:19"
+                },
+                {
+                  "assignments": [
+                    28754
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 28754,
+                      "mutability": "mutable",
+                      "name": "withdrawalCredentialBytes",
+                      "nameLocation": "4537:25:19",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 28797,
+                      "src": "4529:33:19",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes32",
+                        "typeString": "bytes32"
+                      },
+                      "typeName": {
+                        "id": 28753,
+                        "name": "bytes32",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "4529:7:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes32",
+                          "typeString": "bytes32"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 28765,
+                  "initialValue": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "arguments": [
+                              {
+                                "id": 28761,
+                                "name": "_withdrawalCredential",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 28729,
+                                "src": "4602:21:19",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              }
+                            ],
+                            "expression": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              ],
+                              "id": 28760,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "lValueRequested": false,
+                              "nodeType": "ElementaryTypeNameExpression",
+                              "src": "4594:7:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_type$_t_uint160_$",
+                                "typeString": "type(uint160)"
+                              },
+                              "typeName": {
+                                "id": 28759,
+                                "name": "uint160",
+                                "nodeType": "ElementaryTypeName",
+                                "src": "4594:7:19",
+                                "typeDescriptions": {}
+                              }
+                            },
+                            "id": 28762,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": false,
+                            "kind": "typeConversion",
+                            "lValueRequested": false,
+                            "nameLocations": [],
+                            "names": [],
+                            "nodeType": "FunctionCall",
+                            "src": "4594:30:19",
+                            "tryCall": false,
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint160",
+                              "typeString": "uint160"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_uint160",
+                              "typeString": "uint160"
+                            }
+                          ],
+                          "id": 28758,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "lValueRequested": false,
+                          "nodeType": "ElementaryTypeNameExpression",
+                          "src": "4586:7:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_type$_t_uint256_$",
+                            "typeString": "type(uint256)"
+                          },
+                          "typeName": {
+                            "id": 28757,
+                            "name": "uint256",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "4586:7:19",
+                            "typeDescriptions": {}
+                          }
+                        },
+                        "id": 28763,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "kind": "typeConversion",
+                        "lValueRequested": false,
+                        "nameLocations": [],
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "4586:39:19",
+                        "tryCall": false,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "id": 28756,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "lValueRequested": false,
+                      "nodeType": "ElementaryTypeNameExpression",
+                      "src": "4565:7:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_type$_t_bytes32_$",
+                        "typeString": "type(bytes32)"
+                      },
+                      "typeName": {
+                        "id": 28755,
+                        "name": "bytes32",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "4565:7:19",
+                        "typeDescriptions": {}
+                      }
+                    },
+                    "id": 28764,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "typeConversion",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "4565:70:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "4529:106:19"
+                },
+                {
+                  "assignments": [
+                    28767
+                  ],
+                  "declarations": [
+                    {
+                      "constant": false,
+                      "id": 28767,
+                      "mutability": "mutable",
+                      "name": "hash",
+                      "nameLocation": "4653:4:19",
+                      "nodeType": "VariableDeclaration",
+                      "scope": 28797,
+                      "src": "4645:12:19",
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_bytes32",
+                        "typeString": "bytes32"
+                      },
+                      "typeName": {
+                        "id": 28766,
+                        "name": "bytes32",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "4645:7:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes32",
+                          "typeString": "bytes32"
+                        }
+                      },
+                      "visibility": "internal"
+                    }
+                  ],
+                  "id": 28785,
+                  "initialValue": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "arguments": [
+                              {
+                                "hexValue": "30786666",
+                                "id": 28773,
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": true,
+                                "kind": "number",
+                                "lValueRequested": false,
+                                "nodeType": "Literal",
+                                "src": "4724:4:19",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_rational_255_by_1",
+                                  "typeString": "int_const 255"
+                                },
+                                "value": "0xff"
+                              }
+                            ],
+                            "expression": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_rational_255_by_1",
+                                  "typeString": "int_const 255"
+                                }
+                              ],
+                              "id": 28772,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "lValueRequested": false,
+                              "nodeType": "ElementaryTypeNameExpression",
+                              "src": "4717:6:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_type$_t_bytes1_$",
+                                "typeString": "type(bytes1)"
+                              },
+                              "typeName": {
+                                "id": 28771,
+                                "name": "bytes1",
+                                "nodeType": "ElementaryTypeName",
+                                "src": "4717:6:19",
+                                "typeDescriptions": {}
+                              }
+                            },
+                            "id": 28774,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "kind": "typeConversion",
+                            "lValueRequested": false,
+                            "nameLocations": [],
+                            "names": [],
+                            "nodeType": "FunctionCall",
+                            "src": "4717:12:19",
+                            "tryCall": false,
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_bytes1",
+                              "typeString": "bytes1"
+                            }
+                          },
+                          {
+                            "arguments": [
+                              {
+                                "id": 28777,
+                                "name": "this",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": -28,
+                                "src": "4755:4:19",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_contract$_FeeRewardsManager_$28868",
+                                  "typeString": "contract FeeRewardsManager"
+                                }
+                              }
+                            ],
+                            "expression": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_contract$_FeeRewardsManager_$28868",
+                                  "typeString": "contract FeeRewardsManager"
+                                }
+                              ],
+                              "id": 28776,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "lValueRequested": false,
+                              "nodeType": "ElementaryTypeNameExpression",
+                              "src": "4747:7:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_type$_t_address_$",
+                                "typeString": "type(address)"
+                              },
+                              "typeName": {
+                                "id": 28775,
+                                "name": "address",
+                                "nodeType": "ElementaryTypeName",
+                                "src": "4747:7:19",
+                                "typeDescriptions": {}
+                              }
+                            },
+                            "id": 28778,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": false,
+                            "kind": "typeConversion",
+                            "lValueRequested": false,
+                            "nameLocations": [],
+                            "names": [],
+                            "nodeType": "FunctionCall",
+                            "src": "4747:13:19",
+                            "tryCall": false,
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_address",
+                              "typeString": "address"
+                            }
+                          },
+                          {
+                            "id": 28779,
+                            "name": "withdrawalCredentialBytes",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 28754,
+                            "src": "4778:25:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_bytes32",
+                              "typeString": "bytes32"
+                            }
+                          },
+                          {
+                            "arguments": [
+                              {
+                                "id": 28781,
+                                "name": "bytecode",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 28735,
+                                "src": "4831:8:19",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_bytes_memory_ptr",
+                                  "typeString": "bytes memory"
+                                }
+                              }
+                            ],
+                            "expression": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bytes_memory_ptr",
+                                  "typeString": "bytes memory"
+                                }
+                              ],
+                              "id": 28780,
+                              "name": "keccak256",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": -8,
+                              "src": "4821:9:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
+                                "typeString": "function (bytes memory) pure returns (bytes32)"
+                              }
+                            },
+                            "id": 28782,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": false,
+                            "kind": "functionCall",
+                            "lValueRequested": false,
+                            "nameLocations": [],
+                            "names": [],
+                            "nodeType": "FunctionCall",
+                            "src": "4821:19:19",
+                            "tryCall": false,
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_bytes32",
+                              "typeString": "bytes32"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_bytes1",
+                              "typeString": "bytes1"
+                            },
+                            {
+                              "typeIdentifier": "t_address",
+                              "typeString": "address"
+                            },
+                            {
+                              "typeIdentifier": "t_bytes32",
+                              "typeString": "bytes32"
+                            },
+                            {
+                              "typeIdentifier": "t_bytes32",
+                              "typeString": "bytes32"
+                            }
+                          ],
+                          "expression": {
+                            "id": 28769,
+                            "name": "abi",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": -1,
+                            "src": "4683:3:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_magic_abi",
+                              "typeString": "abi"
+                            }
+                          },
+                          "id": 28770,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "lValueRequested": false,
+                          "memberLocation": "4687:12:19",
+                          "memberName": "encodePacked",
+                          "nodeType": "MemberAccess",
+                          "src": "4683:16:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_function_abiencodepacked_pure$__$returns$_t_bytes_memory_ptr_$",
+                            "typeString": "function () pure returns (bytes memory)"
+                          }
+                        },
+                        "id": 28783,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "kind": "functionCall",
+                        "lValueRequested": false,
+                        "nameLocations": [],
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "4683:171:19",
+                        "tryCall": false,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_bytes_memory_ptr",
+                          "typeString": "bytes memory"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_bytes_memory_ptr",
+                          "typeString": "bytes memory"
+                        }
+                      ],
+                      "id": 28768,
+                      "name": "keccak256",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": -8,
+                      "src": "4660:9:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
+                        "typeString": "function (bytes memory) pure returns (bytes32)"
+                      }
+                    },
+                    "id": 28784,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "4660:204:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bytes32",
+                      "typeString": "bytes32"
+                    }
+                  },
+                  "nodeType": "VariableDeclarationStatement",
+                  "src": "4645:219:19"
+                },
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "arguments": [
+                          {
+                            "arguments": [
+                              {
+                                "id": 28792,
+                                "name": "hash",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 28767,
+                                "src": "4902:4:19",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_bytes32",
+                                  "typeString": "bytes32"
+                                }
+                              }
+                            ],
+                            "expression": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bytes32",
+                                  "typeString": "bytes32"
+                                }
+                              ],
+                              "id": 28791,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "lValueRequested": false,
+                              "nodeType": "ElementaryTypeNameExpression",
+                              "src": "4897:4:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_type$_t_uint256_$",
+                                "typeString": "type(uint256)"
+                              },
+                              "typeName": {
+                                "id": 28790,
+                                "name": "uint",
+                                "nodeType": "ElementaryTypeName",
+                                "src": "4897:4:19",
+                                "typeDescriptions": {}
+                              }
+                            },
+                            "id": 28793,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": false,
+                            "kind": "typeConversion",
+                            "lValueRequested": false,
+                            "nameLocations": [],
+                            "names": [],
+                            "nodeType": "FunctionCall",
+                            "src": "4897:10:19",
+                            "tryCall": false,
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_uint256",
+                              "typeString": "uint256"
+                            }
+                          ],
+                          "id": 28789,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "lValueRequested": false,
+                          "nodeType": "ElementaryTypeNameExpression",
+                          "src": "4889:7:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_type$_t_uint160_$",
+                            "typeString": "type(uint160)"
+                          },
+                          "typeName": {
+                            "id": 28788,
+                            "name": "uint160",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "4889:7:19",
+                            "typeDescriptions": {}
+                          }
+                        },
+                        "id": 28794,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "kind": "typeConversion",
+                        "lValueRequested": false,
+                        "nameLocations": [],
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "4889:19:19",
+                        "tryCall": false,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint160",
+                          "typeString": "uint160"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint160",
+                          "typeString": "uint160"
+                        }
+                      ],
+                      "id": 28787,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "lValueRequested": false,
+                      "nodeType": "ElementaryTypeNameExpression",
+                      "src": "4881:7:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_type$_t_address_$",
+                        "typeString": "type(address)"
+                      },
+                      "typeName": {
+                        "id": 28786,
+                        "name": "address",
+                        "nodeType": "ElementaryTypeName",
+                        "src": "4881:7:19",
+                        "typeDescriptions": {}
+                      }
+                    },
+                    "id": 28795,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "typeConversion",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "4881:28:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "functionReturnParameters": 28733,
+                  "id": 28796,
+                  "nodeType": "Return",
+                  "src": "4874:35:19"
+                }
+              ]
+            },
+            "functionSelector": "a900ccec",
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "predictFeeContractAddress",
+            "nameLocation": "4212:25:19",
+            "parameters": {
+              "id": 28730,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28729,
+                  "mutability": "mutable",
+                  "name": "_withdrawalCredential",
+                  "nameLocation": "4255:21:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28798,
+                  "src": "4247:29:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28728,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "4247:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "4237:45:19"
+            },
+            "returnParameters": {
+              "id": 28733,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28732,
+                  "mutability": "mutable",
+                  "name": "",
+                  "nameLocation": "-1:-1:-1",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28798,
+                  "src": "4304:7:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28731,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "4304:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "4303:9:19"
+            },
+            "scope": 28868,
+            "stateMutability": "view",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "id": 28815,
+            "nodeType": "FunctionDefinition",
+            "src": "4922:188:19",
+            "nodes": [],
+            "body": {
+              "id": 28814,
+              "nodeType": "Block",
+              "src": "5035:75:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "id": 28811,
+                        "name": "_newFee",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28802,
+                        "src": "5095:7:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint32",
+                          "typeString": "uint32"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint32",
+                          "typeString": "uint32"
+                        }
+                      ],
+                      "expression": {
+                        "arguments": [
+                          {
+                            "id": 28808,
+                            "name": "_feeContract",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 28800,
+                            "src": "5062:12:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_address_payable",
+                              "typeString": "address payable"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_address_payable",
+                              "typeString": "address payable"
+                            }
+                          ],
+                          "id": 28807,
+                          "name": "RewardsCollector",
+                          "nodeType": "Identifier",
+                          "overloadedDeclarations": [],
+                          "referencedDeclaration": 28650,
+                          "src": "5045:16:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_type$_t_contract$_RewardsCollector_$28650_$",
+                            "typeString": "type(contract RewardsCollector)"
+                          }
+                        },
+                        "id": 28809,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "kind": "typeConversion",
+                        "lValueRequested": false,
+                        "nameLocations": [],
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "5045:30:19",
+                        "tryCall": false,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                          "typeString": "contract RewardsCollector"
+                        }
+                      },
+                      "id": 28810,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "memberLocation": "5076:18:19",
+                      "memberName": "changeFeeNumerator",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 28649,
+                      "src": "5045:49:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_external_nonpayable$_t_uint32_$returns$__$",
+                        "typeString": "function (uint32) external"
+                      }
+                    },
+                    "id": 28812,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "5045:58:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 28813,
+                  "nodeType": "ExpressionStatement",
+                  "src": "5045:58:19"
+                }
+              ]
+            },
+            "functionSelector": "01361090",
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [
+              {
+                "id": 28805,
+                "kind": "modifierInvocation",
+                "modifierName": {
+                  "id": 28804,
+                  "name": "onlyOwner",
+                  "nameLocations": [
+                    "5025:9:19"
+                  ],
+                  "nodeType": "IdentifierPath",
+                  "referencedDeclaration": 31,
+                  "src": "5025:9:19"
+                },
+                "nodeType": "ModifierInvocation",
+                "src": "5025:9:19"
+              }
+            ],
+            "name": "changeFeeNumerator",
+            "nameLocation": "4931:18:19",
+            "parameters": {
+              "id": 28803,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28800,
+                  "mutability": "mutable",
+                  "name": "_feeContract",
+                  "nameLocation": "4975:12:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28815,
+                  "src": "4959:28:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address_payable",
+                    "typeString": "address payable"
+                  },
+                  "typeName": {
+                    "id": 28799,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "4959:15:19",
+                    "stateMutability": "payable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address_payable",
+                      "typeString": "address payable"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 28802,
+                  "mutability": "mutable",
+                  "name": "_newFee",
+                  "nameLocation": "5004:7:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28815,
+                  "src": "4997:14:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint32",
+                    "typeString": "uint32"
+                  },
+                  "typeName": {
+                    "id": 28801,
+                    "name": "uint32",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "4997:6:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint32",
+                      "typeString": "uint32"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "4949:68:19"
+            },
+            "returnParameters": {
+              "id": 28806,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "5035:0:19"
+            },
+            "scope": 28868,
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "id": 28843,
+            "nodeType": "FunctionDefinition",
+            "src": "5116:231:19",
+            "nodes": [],
+            "body": {
+              "id": 28842,
+              "nodeType": "Block",
+              "src": "5207:140:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "body": {
+                    "id": 28840,
+                    "nodeType": "Block",
+                    "src": "5266:75:19",
+                    "statements": [
+                      {
+                        "expression": {
+                          "arguments": [],
+                          "expression": {
+                            "argumentTypes": [],
+                            "expression": {
+                              "arguments": [
+                                {
+                                  "baseExpression": {
+                                    "id": 28833,
+                                    "name": "feeAddresses",
+                                    "nodeType": "Identifier",
+                                    "overloadedDeclarations": [],
+                                    "referencedDeclaration": 28818,
+                                    "src": "5297:12:19",
+                                    "typeDescriptions": {
+                                      "typeIdentifier": "t_array$_t_address_payable_$dyn_calldata_ptr",
+                                      "typeString": "address payable[] calldata"
+                                    }
+                                  },
+                                  "id": 28835,
+                                  "indexExpression": {
+                                    "id": 28834,
+                                    "name": "i",
+                                    "nodeType": "Identifier",
+                                    "overloadedDeclarations": [],
+                                    "referencedDeclaration": 28822,
+                                    "src": "5310:1:19",
+                                    "typeDescriptions": {
+                                      "typeIdentifier": "t_uint32",
+                                      "typeString": "uint32"
+                                    }
+                                  },
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "nodeType": "IndexAccess",
+                                  "src": "5297:15:19",
+                                  "typeDescriptions": {
+                                    "typeIdentifier": "t_address_payable",
+                                    "typeString": "address payable"
+                                  }
+                                }
+                              ],
+                              "expression": {
+                                "argumentTypes": [
+                                  {
+                                    "typeIdentifier": "t_address_payable",
+                                    "typeString": "address payable"
+                                  }
+                                ],
+                                "id": 28832,
+                                "name": "RewardsCollector",
+                                "nodeType": "Identifier",
+                                "overloadedDeclarations": [],
+                                "referencedDeclaration": 28650,
+                                "src": "5280:16:19",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_type$_t_contract$_RewardsCollector_$28650_$",
+                                  "typeString": "type(contract RewardsCollector)"
+                                }
+                              },
+                              "id": 28836,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "kind": "typeConversion",
+                              "lValueRequested": false,
+                              "nameLocations": [],
+                              "names": [],
+                              "nodeType": "FunctionCall",
+                              "src": "5280:33:19",
+                              "tryCall": false,
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                                "typeString": "contract RewardsCollector"
+                              }
+                            },
+                            "id": 28837,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": false,
+                            "lValueRequested": false,
+                            "memberLocation": "5314:14:19",
+                            "memberName": "collectRewards",
+                            "nodeType": "MemberAccess",
+                            "referencedDeclaration": 28610,
+                            "src": "5280:48:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_function_external_payable$__$returns$__$",
+                              "typeString": "function () payable external"
+                            }
+                          },
+                          "id": 28838,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "kind": "functionCall",
+                          "lValueRequested": false,
+                          "nameLocations": [],
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "5280:50:19",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_tuple$__$",
+                            "typeString": "tuple()"
+                          }
+                        },
+                        "id": 28839,
+                        "nodeType": "ExpressionStatement",
+                        "src": "5280:50:19"
+                      }
+                    ]
+                  },
+                  "condition": {
+                    "commonType": {
+                      "typeIdentifier": "t_uint256",
+                      "typeString": "uint256"
+                    },
+                    "id": 28828,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftExpression": {
+                      "id": 28825,
+                      "name": "i",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 28822,
+                      "src": "5236:1:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "nodeType": "BinaryOperation",
+                    "operator": "<",
+                    "rightExpression": {
+                      "expression": {
+                        "id": 28826,
+                        "name": "feeAddresses",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28818,
+                        "src": "5240:12:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_array$_t_address_payable_$dyn_calldata_ptr",
+                          "typeString": "address payable[] calldata"
+                        }
+                      },
+                      "id": 28827,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "memberLocation": "5253:6:19",
+                      "memberName": "length",
+                      "nodeType": "MemberAccess",
+                      "src": "5240:19:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint256",
+                        "typeString": "uint256"
+                      }
+                    },
+                    "src": "5236:23:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_bool",
+                      "typeString": "bool"
+                    }
+                  },
+                  "id": 28841,
+                  "initializationExpression": {
+                    "assignments": [
+                      28822
+                    ],
+                    "declarations": [
+                      {
+                        "constant": false,
+                        "id": 28822,
+                        "mutability": "mutable",
+                        "name": "i",
+                        "nameLocation": "5229:1:19",
+                        "nodeType": "VariableDeclaration",
+                        "scope": 28841,
+                        "src": "5222:8:19",
+                        "stateVariable": false,
+                        "storageLocation": "default",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint32",
+                          "typeString": "uint32"
+                        },
+                        "typeName": {
+                          "id": 28821,
+                          "name": "uint32",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "5222:6:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint32",
+                            "typeString": "uint32"
+                          }
+                        },
+                        "visibility": "internal"
+                      }
+                    ],
+                    "id": 28824,
+                    "initialValue": {
+                      "hexValue": "30",
+                      "id": 28823,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "number",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "5233:1:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_rational_0_by_1",
+                        "typeString": "int_const 0"
+                      },
+                      "value": "0"
+                    },
+                    "nodeType": "VariableDeclarationStatement",
+                    "src": "5222:12:19"
+                  },
+                  "loopExpression": {
+                    "expression": {
+                      "id": 28830,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "nodeType": "UnaryOperation",
+                      "operator": "++",
+                      "prefix": true,
+                      "src": "5261:3:19",
+                      "subExpression": {
+                        "id": 28829,
+                        "name": "i",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 28822,
+                        "src": "5263:1:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint32",
+                          "typeString": "uint32"
+                        }
+                      },
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint32",
+                        "typeString": "uint32"
+                      }
+                    },
+                    "id": 28831,
+                    "nodeType": "ExpressionStatement",
+                    "src": "5261:3:19"
+                  },
+                  "nodeType": "ForStatement",
+                  "src": "5217:124:19"
+                }
+              ]
+            },
+            "functionSelector": "2630be4e",
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [],
+            "name": "batchCollectRewards",
+            "nameLocation": "5125:19:19",
+            "parameters": {
+              "id": 28819,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28818,
+                  "mutability": "mutable",
+                  "name": "feeAddresses",
+                  "nameLocation": "5181:12:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28843,
+                  "src": "5154:39:19",
+                  "stateVariable": false,
+                  "storageLocation": "calldata",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_array$_t_address_payable_$dyn_calldata_ptr",
+                    "typeString": "address payable[]"
+                  },
+                  "typeName": {
+                    "baseType": {
+                      "id": 28816,
+                      "name": "address",
+                      "nodeType": "ElementaryTypeName",
+                      "src": "5154:15:19",
+                      "stateMutability": "payable",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address_payable",
+                        "typeString": "address payable"
+                      }
+                    },
+                    "id": 28817,
+                    "nodeType": "ArrayTypeName",
+                    "src": "5154:17:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_array$_t_address_payable_$dyn_storage_ptr",
+                      "typeString": "address payable[]"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "5144:55:19"
+            },
+            "returnParameters": {
+              "id": 28820,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "5207:0:19"
+            },
+            "scope": 28868,
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "public"
+          },
+          {
+            "id": 28847,
+            "nodeType": "FunctionDefinition",
+            "src": "5353:29:19",
+            "nodes": [],
+            "body": {
+              "id": 28846,
+              "nodeType": "Block",
+              "src": "5380:2:19",
+              "nodes": [],
+              "statements": []
+            },
+            "implemented": true,
+            "kind": "receive",
+            "modifiers": [],
+            "name": "",
+            "nameLocation": "-1:-1:-1",
+            "parameters": {
+              "id": 28844,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "5360:2:19"
+            },
+            "returnParameters": {
+              "id": 28845,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "5380:0:19"
+            },
+            "scope": 28868,
+            "stateMutability": "payable",
+            "virtual": false,
+            "visibility": "external"
+          },
+          {
+            "id": 28867,
+            "nodeType": "FunctionDefinition",
+            "src": "5436:111:19",
+            "nodes": [],
+            "body": {
+              "id": 28866,
+              "nodeType": "Block",
+              "src": "5485:62:19",
+              "nodes": [],
+              "statements": [
+                {
+                  "expression": {
+                    "arguments": [
+                      {
+                        "expression": {
+                          "arguments": [
+                            {
+                              "id": 28861,
+                              "name": "this",
+                              "nodeType": "Identifier",
+                              "overloadedDeclarations": [],
+                              "referencedDeclaration": -28,
+                              "src": "5526:4:19",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_contract$_FeeRewardsManager_$28868",
+                                "typeString": "contract FeeRewardsManager"
+                              }
+                            }
+                          ],
+                          "expression": {
+                            "argumentTypes": [
+                              {
+                                "typeIdentifier": "t_contract$_FeeRewardsManager_$28868",
+                                "typeString": "contract FeeRewardsManager"
+                              }
+                            ],
+                            "id": 28860,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "lValueRequested": false,
+                            "nodeType": "ElementaryTypeNameExpression",
+                            "src": "5518:7:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_type$_t_address_$",
+                              "typeString": "type(address)"
+                            },
+                            "typeName": {
+                              "id": 28859,
+                              "name": "address",
+                              "nodeType": "ElementaryTypeName",
+                              "src": "5518:7:19",
+                              "typeDescriptions": {}
+                            }
+                          },
+                          "id": 28862,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "kind": "typeConversion",
+                          "lValueRequested": false,
+                          "nameLocations": [],
+                          "names": [],
+                          "nodeType": "FunctionCall",
+                          "src": "5518:13:19",
+                          "tryCall": false,
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          }
+                        },
+                        "id": 28863,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "lValueRequested": false,
+                        "memberLocation": "5532:7:19",
+                        "memberName": "balance",
+                        "nodeType": "MemberAccess",
+                        "src": "5518:21:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      }
+                    ],
+                    "expression": {
+                      "argumentTypes": [
+                        {
+                          "typeIdentifier": "t_uint256",
+                          "typeString": "uint256"
+                        }
+                      ],
+                      "expression": {
+                        "arguments": [
+                          {
+                            "id": 28856,
+                            "name": "addr",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 28849,
+                            "src": "5503:4:19",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_address",
+                              "typeString": "address"
+                            }
+                          }
+                        ],
+                        "expression": {
+                          "argumentTypes": [
+                            {
+                              "typeIdentifier": "t_address",
+                              "typeString": "address"
+                            }
+                          ],
+                          "id": 28855,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "lValueRequested": false,
+                          "nodeType": "ElementaryTypeNameExpression",
+                          "src": "5495:8:19",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_type$_t_address_payable_$",
+                            "typeString": "type(address payable)"
+                          },
+                          "typeName": {
+                            "id": 28854,
+                            "name": "address",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "5495:8:19",
+                            "stateMutability": "payable",
+                            "typeDescriptions": {}
+                          }
+                        },
+                        "id": 28857,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": false,
+                        "kind": "typeConversion",
+                        "lValueRequested": false,
+                        "nameLocations": [],
+                        "names": [],
+                        "nodeType": "FunctionCall",
+                        "src": "5495:13:19",
+                        "tryCall": false,
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_address_payable",
+                          "typeString": "address payable"
+                        }
+                      },
+                      "id": 28858,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "memberLocation": "5509:8:19",
+                      "memberName": "transfer",
+                      "nodeType": "MemberAccess",
+                      "src": "5495:22:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_function_transfer_nonpayable$_t_uint256_$returns$__$",
+                        "typeString": "function (uint256)"
+                      }
+                    },
+                    "id": 28864,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "kind": "functionCall",
+                    "lValueRequested": false,
+                    "nameLocations": [],
+                    "names": [],
+                    "nodeType": "FunctionCall",
+                    "src": "5495:45:19",
+                    "tryCall": false,
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_tuple$__$",
+                      "typeString": "tuple()"
+                    }
+                  },
+                  "id": 28865,
+                  "nodeType": "ExpressionStatement",
+                  "src": "5495:45:19"
+                }
+              ]
+            },
+            "functionSelector": "6a953e09",
+            "implemented": true,
+            "kind": "function",
+            "modifiers": [
+              {
+                "id": 28852,
+                "kind": "modifierInvocation",
+                "modifierName": {
+                  "id": 28851,
+                  "name": "onlyOwner",
+                  "nameLocations": [
+                    "5475:9:19"
+                  ],
+                  "nodeType": "IdentifierPath",
+                  "referencedDeclaration": 31,
+                  "src": "5475:9:19"
+                },
+                "nodeType": "ModifierInvocation",
+                "src": "5475:9:19"
+              }
+            ],
+            "name": "getEth",
+            "nameLocation": "5445:6:19",
+            "parameters": {
+              "id": 28850,
+              "nodeType": "ParameterList",
+              "parameters": [
+                {
+                  "constant": false,
+                  "id": 28849,
+                  "mutability": "mutable",
+                  "name": "addr",
+                  "nameLocation": "5460:4:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 28867,
+                  "src": "5452:12:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  },
+                  "typeName": {
+                    "id": 28848,
+                    "name": "address",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "5452:7:19",
+                    "stateMutability": "nonpayable",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_address",
+                      "typeString": "address"
+                    }
+                  },
+                  "visibility": "internal"
+                }
+              ],
+              "src": "5451:14:19"
+            },
+            "returnParameters": {
+              "id": 28853,
+              "nodeType": "ParameterList",
+              "parameters": [],
+              "src": "5485:0:19"
+            },
+            "scope": 28868,
+            "stateMutability": "nonpayable",
+            "virtual": false,
+            "visibility": "external"
+          }
+        ],
+        "abstract": false,
+        "baseContracts": [
+          {
+            "baseName": {
+              "id": 28651,
+              "name": "Ownable",
+              "nameLocations": [
+                "2918:7:19"
+              ],
+              "nodeType": "IdentifierPath",
+              "referencedDeclaration": 112,
+              "src": "2918:7:19"
+            },
+            "id": 28652,
+            "nodeType": "InheritanceSpecifier",
+            "src": "2918:7:19"
+          }
+        ],
+        "canonicalName": "FeeRewardsManager",
+        "contractDependencies": [
+          28650
+        ],
+        "contractKind": "contract",
+        "fullyImplemented": true,
+        "linearizedBaseContracts": [
+          28868,
+          112,
+          134
+        ],
+        "name": "FeeRewardsManager",
+        "nameLocation": "2897:17:19",
+        "scope": 28869,
+        "usedErrors": [],
+        "usedEvents": [
+          13,
+          28670
+        ]
+      }
+    ],
+    "license": "BSD-3-Clause"
+  },
+  "id": 19
+}

--- a/eth_possim/resources/ethereum_compiled_contracts/FeeRewardsManager.json
+++ b/eth_possim/resources/ethereum_compiled_contracts/FeeRewardsManager.json
@@ -1,0 +1,5480 @@
+{
+    "abi": [
+        {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "_defaultFeeNumerator",
+                    "type": "uint32"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "constructor"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": false,
+                    "internalType": "address",
+                    "name": "contractAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "uint32",
+                    "name": "feeNumerator",
+                    "type": "uint32"
+                }
+            ],
+            "name": "ContractDeployed",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "previousOwner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "OwnershipTransferred",
+            "type": "event"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address payable[]",
+                    "name": "feeAddresses",
+                    "type": "address[]"
+                }
+            ],
+            "name": "batchCollectRewards",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "_newFeeNumerator",
+                    "type": "uint32"
+                }
+            ],
+            "name": "changeDefaultFee",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address payable",
+                    "name": "_feeContract",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint32",
+                    "name": "_newFee",
+                    "type": "uint32"
+                }
+            ],
+            "name": "changeFeeNumerator",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_withdrawalCredential",
+                    "type": "address"
+                }
+            ],
+            "name": "createFeeContract",
+            "outputs": [
+                {
+                    "internalType": "address payable",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "defaultFeeNumerator",
+            "outputs": [
+                {
+                    "internalType": "uint32",
+                    "name": "",
+                    "type": "uint32"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "addr",
+                    "type": "address"
+                }
+            ],
+            "name": "getEth",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "owner",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "_withdrawalCredential",
+                    "type": "address"
+                }
+            ],
+            "name": "predictFeeContractAddress",
+            "outputs": [
+                {
+                    "internalType": "address",
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "renounceOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "newOwner",
+                    "type": "address"
+                }
+            ],
+            "name": "transferOwnership",
+            "outputs": [],
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "stateMutability": "payable",
+            "type": "receive"
+        }
+    ],
+    "bytecode": {
+        "object": "0x608060405234801561001057600080fd5b50604051610cc6380380610cc683398101604081905261002f916100b1565b61003833610061565b6000805463ffffffff909216600160a01b0263ffffffff60a01b199092169190911790556100de565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6000602082840312156100c357600080fd5b815163ffffffff811681146100d757600080fd5b9392505050565b610bd9806100ed6000396000f3fe6080604052600436106100955760003560e01c80638da5cb5b116100595780638da5cb5b14610155578063a900ccec14610173578063af3f6f4d14610193578063ef5828d0146101cc578063f2fde38b146101ec57600080fd5b806301361090146100a15780632630be4e146100c3578063673c949d146100e35780636a953e0914610120578063715018a61461014057600080fd5b3661009c57005b600080fd5b3480156100ad57600080fd5b506100c16100bc3660046106b2565b61020c565b005b3480156100cf57600080fd5b506100c16100de3660046106e7565b610277565b3480156100ef57600080fd5b506101036100fe36600461075c565b61031d565b6040516001600160a01b0390911681526020015b60405180910390f35b34801561012c57600080fd5b506100c161013b36600461075c565b6103e9565b34801561014c57600080fd5b506100c161042a565b34801561016157600080fd5b506000546001600160a01b0316610103565b34801561017f57600080fd5b5061010361018e36600461075c565b61043e565b34801561019f57600080fd5b506000546101b790600160a01b900463ffffffff1681565b60405163ffffffff9091168152602001610117565b3480156101d857600080fd5b506100c16101e7366004610780565b610521565b3480156101f857600080fd5b506100c161020736600461075c565b61054f565b6102146105cd565b6040516335c8427760e01b815263ffffffff821660048201526001600160a01b038316906335c8427790602401600060405180830381600087803b15801561025b57600080fd5b505af115801561026f573d6000803e3d6000fd5b505050505050565b60005b63ffffffff81168211156103185782828263ffffffff168181106102a0576102a061079b565b90506020020160208101906102b5919061075c565b6001600160a01b03166370bb45b36040518163ffffffff1660e01b8152600401600060405180830381600087803b1580156102ef57600080fd5b505af1158015610303573d6000803e3d6000fd5b5050505080610311906107b1565b905061027a565b505050565b600080826001600160a01b031660001b905060008184600060149054906101000a900463ffffffff1660405161035290610677565b6001600160a01b03909216825263ffffffff1660208201526040018190604051809103906000f590508015801561038d573d6000803e3d6000fd5b50600054604080516001600160a01b0384168152600160a01b90920463ffffffff1660208301529192507f620dca0c9d04f7cea9d7f31e571d74acccd54c21dc8ff8855ec1d5a21733c26b910160405180910390a19392505050565b6103f16105cd565b6040516001600160a01b038216904780156108fc02916000818181858888f19350505050158015610426573d6000803e3d6000fd5b5050565b6104326105cd565b61043c6000610627565b565b6000806040518060200161045190610677565b601f1982820381018352601f9091011660408181526000546001600160a01b038716602084015263ffffffff600160a01b9091041681830152805180830382018152606083019091529192506104ab918391608001610812565b60408051601f1981840301815282825280516020918201206001600160f81b0319828501523060601b6bffffffffffffffffffffffff191660218501526001600160a01b039690961660358401526055808401969096528151808403909601865260759092019052835193019290922092915050565b6105296105cd565b6000805463ffffffff909216600160a01b0263ffffffff60a01b19909216919091179055565b6105576105cd565b6001600160a01b0381166105c15760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b60648201526084015b60405180910390fd5b6105ca81610627565b50565b6000546001600160a01b0316331461043c5760405162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e657260448201526064016105b8565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6103748061083083390190565b6001600160a01b03811681146105ca57600080fd5b803563ffffffff811681146106ad57600080fd5b919050565b600080604083850312156106c557600080fd5b82356106d081610684565b91506106de60208401610699565b90509250929050565b600080602083850312156106fa57600080fd5b823567ffffffffffffffff8082111561071257600080fd5b818501915085601f83011261072657600080fd5b81358181111561073557600080fd5b8660208260051b850101111561074a57600080fd5b60209290920196919550909350505050565b60006020828403121561076e57600080fd5b813561077981610684565b9392505050565b60006020828403121561079257600080fd5b61077982610699565b634e487b7160e01b600052603260045260246000fd5b600063ffffffff8083168181036107d857634e487b7160e01b600052601160045260246000fd5b6001019392505050565b6000815160005b8181101561080357602081850181015186830152016107e9565b50600093019283525090919050565b600061082761082183866107e2565b846107e2565b94935050505056fe608060405234801561001057600080fd5b5060405161037438038061037483398101604081905261002f91610076565b6000805463ffffffff909216600160a01b026001600160c01b03199092166001600160a01b0390931692909217179055600180546001600160a01b031916331790556100c5565b6000806040838503121561008957600080fd5b82516001600160a01b03811681146100a057600080fd5b602084015190925063ffffffff811681146100ba57600080fd5b809150509250929050565b6102a0806100d46000396000f3fe60806040526004361061004e5760003560e01c8063230b9da31461005a57806335c842771461009757806370bb45b3146100b957806383059303146100c1578063e86dea4a146100e157600080fd5b3661005557005b600080fd5b34801561006657600080fd5b5060015461007a906001600160a01b031681565b6040516001600160a01b0390911681526020015b60405180910390f35b3480156100a357600080fd5b506100b76100b236600461023d565b61011a565b005b6100b76101b0565b3480156100cd57600080fd5b5060005461007a906001600160a01b031681565b3480156100ed57600080fd5b5060005461010590600160a01b900463ffffffff1681565b60405163ffffffff909116815260200161008e565b6001546001600160a01b0316331461018a5760405162461bcd60e51b815260206004820152602960248201527f4368616e6765466565206e6f742063616c6c65642066726f6d20706172656e746044820152680818dbdb9d1c9858dd60ba1b606482015260840160405180910390fd5b6000805463ffffffff909216600160a01b0263ffffffff60a01b19909216919091179055565b60005460015460405163ea788f4360e01b8152600160a01b830463ffffffff1660048201526001600160a01b0391821660248201529116604482015273__$c56d76a1417c078a963cba4fa22c45184c$__9063ea788f439060640160006040518083038186803b15801561022357600080fd5b505af4158015610237573d6000803e3d6000fd5b50505050565b60006020828403121561024f57600080fd5b813563ffffffff8116811461026357600080fd5b939250505056fea264697066735822122066a2ab64342090ae4ac32d24120d45f6850a430fefa09a9390d57ffc7d754d3e64736f6c63430008140033a26469706673582212201d2b8bc53bada45dfd2c1bca271919ec861e2df7a5d7b24efbf4b1de9c0182e864736f6c63430008140033",
+        "sourceMap": "2888:2661:19:-:0;;;2972:100;;;;;;;;;;;;;;;;;;;;;;;;;;;;:::i;:::-;936:32:0;719:10:1;936:18:0;:32::i;:::-;3023:19:19;:42;;;;;;-1:-1:-1;;;3023:42:19;-1:-1:-1;;;;3023:42:19;;;;;;;;;2888:2661;;2426:187:0;2499:16;2518:6;;-1:-1:-1;;;;;2534:17:0;;;-1:-1:-1;;;;;;2534:17:0;;;;;;2566:40;;2518:6;;;;;;;2566:40;;2499:16;2566:40;2489:124;2426:187;:::o;14:280:21:-;83:6;136:2;124:9;115:7;111:23;107:32;104:52;;;152:1;149;142:12;104:52;184:9;178:16;234:10;227:5;223:22;216:5;213:33;203:61;;260:1;257;250:12;203:61;283:5;14:280;-1:-1:-1;;;14:280:21:o;:::-;2888:2661:19;;;;;;",
+        "linkReferences": {
+            "src/FeeRewardsManager.sol": {
+                "CalculateAndSendRewards": [
+                    {
+                        "start": 3039,
+                        "length": 20
+                    }
+                ]
+            }
+        }
+    },
+    "deployedBytecode": {
+        "object": "0x6080604052600436106100955760003560e01c80638da5cb5b116100595780638da5cb5b14610155578063a900ccec14610173578063af3f6f4d14610193578063ef5828d0146101cc578063f2fde38b146101ec57600080fd5b806301361090146100a15780632630be4e146100c3578063673c949d146100e35780636a953e0914610120578063715018a61461014057600080fd5b3661009c57005b600080fd5b3480156100ad57600080fd5b506100c16100bc3660046106b2565b61020c565b005b3480156100cf57600080fd5b506100c16100de3660046106e7565b610277565b3480156100ef57600080fd5b506101036100fe36600461075c565b61031d565b6040516001600160a01b0390911681526020015b60405180910390f35b34801561012c57600080fd5b506100c161013b36600461075c565b6103e9565b34801561014c57600080fd5b506100c161042a565b34801561016157600080fd5b506000546001600160a01b0316610103565b34801561017f57600080fd5b5061010361018e36600461075c565b61043e565b34801561019f57600080fd5b506000546101b790600160a01b900463ffffffff1681565b60405163ffffffff9091168152602001610117565b3480156101d857600080fd5b506100c16101e7366004610780565b610521565b3480156101f857600080fd5b506100c161020736600461075c565b61054f565b6102146105cd565b6040516335c8427760e01b815263ffffffff821660048201526001600160a01b038316906335c8427790602401600060405180830381600087803b15801561025b57600080fd5b505af115801561026f573d6000803e3d6000fd5b505050505050565b60005b63ffffffff81168211156103185782828263ffffffff168181106102a0576102a061079b565b90506020020160208101906102b5919061075c565b6001600160a01b03166370bb45b36040518163ffffffff1660e01b8152600401600060405180830381600087803b1580156102ef57600080fd5b505af1158015610303573d6000803e3d6000fd5b5050505080610311906107b1565b905061027a565b505050565b600080826001600160a01b031660001b905060008184600060149054906101000a900463ffffffff1660405161035290610677565b6001600160a01b03909216825263ffffffff1660208201526040018190604051809103906000f590508015801561038d573d6000803e3d6000fd5b50600054604080516001600160a01b0384168152600160a01b90920463ffffffff1660208301529192507f620dca0c9d04f7cea9d7f31e571d74acccd54c21dc8ff8855ec1d5a21733c26b910160405180910390a19392505050565b6103f16105cd565b6040516001600160a01b038216904780156108fc02916000818181858888f19350505050158015610426573d6000803e3d6000fd5b5050565b6104326105cd565b61043c6000610627565b565b6000806040518060200161045190610677565b601f1982820381018352601f9091011660408181526000546001600160a01b038716602084015263ffffffff600160a01b9091041681830152805180830382018152606083019091529192506104ab918391608001610812565b60408051601f1981840301815282825280516020918201206001600160f81b0319828501523060601b6bffffffffffffffffffffffff191660218501526001600160a01b039690961660358401526055808401969096528151808403909601865260759092019052835193019290922092915050565b6105296105cd565b6000805463ffffffff909216600160a01b0263ffffffff60a01b19909216919091179055565b6105576105cd565b6001600160a01b0381166105c15760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b60648201526084015b60405180910390fd5b6105ca81610627565b50565b6000546001600160a01b0316331461043c5760405162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e657260448201526064016105b8565b600080546001600160a01b038381166001600160a01b0319831681178455604051919092169283917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e09190a35050565b6103748061083083390190565b6001600160a01b03811681146105ca57600080fd5b803563ffffffff811681146106ad57600080fd5b919050565b600080604083850312156106c557600080fd5b82356106d081610684565b91506106de60208401610699565b90509250929050565b600080602083850312156106fa57600080fd5b823567ffffffffffffffff8082111561071257600080fd5b818501915085601f83011261072657600080fd5b81358181111561073557600080fd5b8660208260051b850101111561074a57600080fd5b60209290920196919550909350505050565b60006020828403121561076e57600080fd5b813561077981610684565b9392505050565b60006020828403121561079257600080fd5b61077982610699565b634e487b7160e01b600052603260045260246000fd5b600063ffffffff8083168181036107d857634e487b7160e01b600052601160045260246000fd5b6001019392505050565b6000815160005b8181101561080357602081850181015186830152016107e9565b50600093019283525090919050565b600061082761082183866107e2565b846107e2565b94935050505056fe608060405234801561001057600080fd5b5060405161037438038061037483398101604081905261002f91610076565b6000805463ffffffff909216600160a01b026001600160c01b03199092166001600160a01b0390931692909217179055600180546001600160a01b031916331790556100c5565b6000806040838503121561008957600080fd5b82516001600160a01b03811681146100a057600080fd5b602084015190925063ffffffff811681146100ba57600080fd5b809150509250929050565b6102a0806100d46000396000f3fe60806040526004361061004e5760003560e01c8063230b9da31461005a57806335c842771461009757806370bb45b3146100b957806383059303146100c1578063e86dea4a146100e157600080fd5b3661005557005b600080fd5b34801561006657600080fd5b5060015461007a906001600160a01b031681565b6040516001600160a01b0390911681526020015b60405180910390f35b3480156100a357600080fd5b506100b76100b236600461023d565b61011a565b005b6100b76101b0565b3480156100cd57600080fd5b5060005461007a906001600160a01b031681565b3480156100ed57600080fd5b5060005461010590600160a01b900463ffffffff1681565b60405163ffffffff909116815260200161008e565b6001546001600160a01b0316331461018a5760405162461bcd60e51b815260206004820152602960248201527f4368616e6765466565206e6f742063616c6c65642066726f6d20706172656e746044820152680818dbdb9d1c9858dd60ba1b606482015260840160405180910390fd5b6000805463ffffffff909216600160a01b0263ffffffff60a01b19909216919091179055565b60005460015460405163ea788f4360e01b8152600160a01b830463ffffffff1660048201526001600160a01b0391821660248201529116604482015273__$c56d76a1417c078a963cba4fa22c45184c$__9063ea788f439060640160006040518083038186803b15801561022357600080fd5b505af4158015610237573d6000803e3d6000fd5b50505050565b60006020828403121561024f57600080fd5b813563ffffffff8116811461026357600080fd5b939250505056fea264697066735822122066a2ab64342090ae4ac32d24120d45f6850a430fefa09a9390d57ffc7d754d3e64736f6c63430008140033a26469706673582212201d2b8bc53bada45dfd2c1bca271919ec861e2df7a5d7b24efbf4b1de9c0182e864736f6c63430008140033",
+        "sourceMap": "2888:2661:19:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;4922:188;;;;;;;;;;-1:-1:-1;4922:188:19;;;;;:::i;:::-;;:::i;:::-;;5116:231;;;;;;;;;;-1:-1:-1;5116:231:19;;;;;:::i;:::-;;:::i;3282:551::-;;;;;;;;;;-1:-1:-1;3282:551:19;;;;;:::i;:::-;;:::i;:::-;;;-1:-1:-1;;;;;1734:32:21;;;1716:51;;1704:2;1689:18;3282:551:19;;;;;;;;5436:111;;;;;;;;;;-1:-1:-1;5436:111:19;;;;;:::i;:::-;;:::i;1824:101:0:-;;;;;;;;;;;;;:::i;1201:85::-;;;;;;;;;;-1:-1:-1;1247:7:0;1273:6;-1:-1:-1;;;;;1273:6:0;1201:85;;4203:713:19;;;;;;;;;;-1:-1:-1;4203:713:19;;;;;:::i;:::-;;:::i;2932:33::-;;;;;;;;;;-1:-1:-1;2932:33:19;;;;-1:-1:-1;;;2932:33:19;;;;;;;;;2160:10:21;2148:23;;;2130:42;;2118:2;2103:18;2932:33:19;1986:192:21;3153:123:19;;;;;;;;;;-1:-1:-1;3153:123:19;;;;;:::i;:::-;;:::i;2074:198:0:-;;;;;;;;;;-1:-1:-1;2074:198:0;;;;;:::i;:::-;;:::i;4922:188:19:-;1094:13:0;:11;:13::i;:::-;5045:58:19::1;::::0;-1:-1:-1;;;5045:58:19;;2160:10:21;2148:23;;5045:58:19::1;::::0;::::1;2130:42:21::0;-1:-1:-1;;;;;5045:49:19;::::1;::::0;::::1;::::0;2103:18:21;;5045:58:19::1;;;;;;;;;;;;;;;;;::::0;::::1;;;;;;;;;;;;::::0;::::1;;;;;;;;;4922:188:::0;;:::o;5116:231::-;5222:8;5217:124;5236:23;;;;-1:-1:-1;5217:124:19;;;5297:12;;5310:1;5297:15;;;;;;;;;:::i;:::-;;;;;;;;;;;;;;:::i;:::-;-1:-1:-1;;;;;5280:48:19;;:50;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;5261:3;;;;:::i;:::-;;;5217:124;;;;5116:231;;:::o;3282:551::-;3370:15;3397:33;3470:21;-1:-1:-1;;;;;3454:39:19;3433:70;;3397:106;;3513:12;3612:25;3656:21;3695:19;;;;;;;;;;;3585:143;;;;;:::i;:::-;-1:-1:-1;;;;;3265:32:21;;;3247:51;;3346:10;3334:23;3329:2;3314:18;;3307:51;3235:2;3220:18;3585:143:19;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;3776:19:19;;3753:43;;;-1:-1:-1;;;;;3265:32:21;;3247:51;;-1:-1:-1;;;3776:19:19;;;;;3329:2:21;3314:18;;3307:51;3265:32;;-1:-1:-1;3753:43:19;;3220:18:21;3753:43:19;;;;;;;3821:4;3282:551;-1:-1:-1;;;3282:551:19:o;5436:111::-;1094:13:0;:11;:13::i;:::-;5495:45:19::1;::::0;-1:-1:-1;;;;;5495:22:19;::::1;::::0;5518:21:::1;5495:45:::0;::::1;;;::::0;::::1;::::0;;;5518:21;5495:22;:45;::::1;;;;;;;;;;;;;::::0;::::1;;;;;;5436:111:::0;:::o;1824:101:0:-;1094:13;:11;:13::i;:::-;1888:30:::1;1915:1;1888:18;:30::i;:::-;1824:101::o:0;4203:713:19:-;4304:7;4323:21;4347:35;;;;;;;;:::i;:::-;-1:-1:-1;;4347:35:19;;;;;;;;;;;;;;;;4489:19;;-1:-1:-1;;;;;3265:32:21;;4347:35:19;4455:54;;3247:51:21;4489:19:19;-1:-1:-1;;;4489:19:19;;;;3314:18:21;;;3307:51;4455:54:19;;;;;;;;;3220:18:21;;;4455:54:19;;;4347:35;;-1:-1:-1;4403:116:19;;4347:35;;4403:116;;;:::i;:::-;;;;-1:-1:-1;;4403:116:19;;;;;;;;;4821:19;;4403:116;4821:19;;;;-1:-1:-1;;;;;;4683:171:19;;;4173:39:21;4755:4:19;4249:2:21;4245:15;-1:-1:-1;;4241:53:21;4228:11;;;4221:74;-1:-1:-1;;;;;4586:39:19;;;;4311:12:21;;;4304:28;4348:12;;;;4341:28;;;;4683:171:19;;;;;;;;;;4385:12:21;;;;4683:171:19;;4660:204;;;;;;;;;;-1:-1:-1;;4203:713:19:o;3153:123::-;1094:13:0;:11;:13::i;:::-;3231:19:19::1;:38:::0;;::::1;::::0;;::::1;-1:-1:-1::0;;;3231:38:19::1;-1:-1:-1::0;;;;3231:38:19;;::::1;::::0;;;::::1;::::0;;3153:123::o;2074:198:0:-;1094:13;:11;:13::i;:::-;-1:-1:-1;;;;;2162:22:0;::::1;2154:73;;;::::0;-1:-1:-1;;;2154:73:0;;4610:2:21;2154:73:0::1;::::0;::::1;4592:21:21::0;4649:2;4629:18;;;4622:30;4688:34;4668:18;;;4661:62;-1:-1:-1;;;4739:18:21;;;4732:36;4785:19;;2154:73:0::1;;;;;;;;;2237:28;2256:8;2237:18;:28::i;:::-;2074:198:::0;:::o;1359:130::-;1247:7;1273:6;-1:-1:-1;;;;;1273:6:0;719:10:1;1422:23:0;1414:68;;;;-1:-1:-1;;;1414:68:0;;5017:2:21;1414:68:0;;;4999:21:21;;;5036:18;;;5029:30;5095:34;5075:18;;;5068:62;5147:18;;1414:68:0;4815:356:21;2426:187:0;2499:16;2518:6;;-1:-1:-1;;;;;2534:17:0;;;-1:-1:-1;;;;;;2534:17:0;;;;;;2566:40;;2518:6;;;;;;;2566:40;;2499:16;2566:40;2489:124;2426:187;:::o;-1:-1:-1:-;;;;;;;;:::o;14:139:21:-;-1:-1:-1;;;;;97:31:21;;87:42;;77:70;;143:1;140;133:12;158:163;225:20;;285:10;274:22;;264:33;;254:61;;311:1;308;301:12;254:61;158:163;;;:::o;326:335::-;401:6;409;462:2;450:9;441:7;437:23;433:32;430:52;;;478:1;475;468:12;430:52;517:9;504:23;536:39;569:5;536:39;:::i;:::-;594:5;-1:-1:-1;618:37:21;651:2;636:18;;618:37;:::i;:::-;608:47;;326:335;;;;;:::o;666:623::-;760:6;768;821:2;809:9;800:7;796:23;792:32;789:52;;;837:1;834;827:12;789:52;877:9;864:23;906:18;947:2;939:6;936:14;933:34;;;963:1;960;953:12;933:34;1001:6;990:9;986:22;976:32;;1046:7;1039:4;1035:2;1031:13;1027:27;1017:55;;1068:1;1065;1058:12;1017:55;1108:2;1095:16;1134:2;1126:6;1123:14;1120:34;;;1150:1;1147;1140:12;1120:34;1203:7;1198:2;1188:6;1185:1;1181:14;1177:2;1173:23;1169:32;1166:45;1163:65;;;1224:1;1221;1214:12;1163:65;1255:2;1247:11;;;;;1277:6;;-1:-1:-1;666:623:21;;-1:-1:-1;;;;666:623:21:o;1294:255::-;1353:6;1406:2;1394:9;1385:7;1381:23;1377:32;1374:52;;;1422:1;1419;1412:12;1374:52;1461:9;1448:23;1480:39;1513:5;1480:39;:::i;:::-;1538:5;1294:255;-1:-1:-1;;;1294:255:21:o;2183:184::-;2241:6;2294:2;2282:9;2273:7;2269:23;2265:32;2262:52;;;2310:1;2307;2300:12;2262:52;2333:28;2351:9;2333:28;:::i;2372:127::-;2433:10;2428:3;2424:20;2421:1;2414:31;2464:4;2461:1;2454:15;2488:4;2485:1;2478:15;2772:298;2810:3;2838:10;2883:2;2876:5;2872:14;2910:2;2901:7;2898:15;2895:138;;2955:10;2950:3;2946:20;2943:1;2936:31;2990:4;2987:1;2980:15;3018:4;3015:1;3008:15;2895:138;3062:1;3049:15;;2772:298;-1:-1:-1;;;2772:298:21:o;3369:322::-;3410:3;3448:5;3442:12;3472:1;3482:128;3496:6;3493:1;3490:13;3482:128;;;3593:4;3578:13;;;3574:24;;3568:31;3555:11;;;3548:52;3511:12;3482:128;;;-1:-1:-1;3665:1:21;3629:16;;3654:13;;;-1:-1:-1;3629:16:21;;3369:322;-1:-1:-1;3369:322:21:o;3696:261::-;3871:3;3896:55;3921:29;3946:3;3938:6;3921:29;:::i;:::-;3913:6;3896:55;:::i;:::-;3889:62;3696:261;-1:-1:-1;;;;3696:261:21:o",
+        "linkReferences": {
+            "src/FeeRewardsManager.sol": {
+                "CalculateAndSendRewards": [
+                    {
+                        "start": 2802,
+                        "length": 20
+                    }
+                ]
+            }
+        }
+    },
+    "methodIdentifiers": {
+        "batchCollectRewards(address[])": "2630be4e",
+        "changeDefaultFee(uint32)": "ef5828d0",
+        "changeFeeNumerator(address,uint32)": "01361090",
+        "createFeeContract(address)": "673c949d",
+        "defaultFeeNumerator()": "af3f6f4d",
+        "getEth(address)": "6a953e09",
+        "owner()": "8da5cb5b",
+        "predictFeeContractAddress(address)": "a900ccec",
+        "renounceOwnership()": "715018a6",
+        "transferOwnership(address)": "f2fde38b"
+    },
+    "rawMetadata": "{\"compiler\":{\"version\":\"0.8.20+commit.a1b79de6\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_defaultFeeNumerator\",\"type\":\"uint32\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"contractAddress\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint32\",\"name\":\"feeNumerator\",\"type\":\"uint32\"}],\"name\":\"ContractDeployed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address payable[]\",\"name\":\"feeAddresses\",\"type\":\"address[]\"}],\"name\":\"batchCollectRewards\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_newFeeNumerator\",\"type\":\"uint32\"}],\"name\":\"changeDefaultFee\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address payable\",\"name\":\"_feeContract\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"_newFee\",\"type\":\"uint32\"}],\"name\":\"changeFeeNumerator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_withdrawalCredential\",\"type\":\"address\"}],\"name\":\"createFeeContract\",\"outputs\":[{\"internalType\":\"address payable\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"defaultFeeNumerator\",\"outputs\":[{\"internalType\":\"uint32\",\"name\":\"\",\"type\":\"uint32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"getEth\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_withdrawalCredential\",\"type\":\"address\"}],\"name\":\"predictFeeContractAddress\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{\"owner()\":{\"details\":\"Returns the address of the current owner.\"},\"renounceOwnership()\":{\"details\":\"Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner.\"},\"transferOwnership(address)\":{\"details\":\"Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.\"}},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/FeeRewardsManager.sol\":\"FeeRewardsManager\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":@openzeppelin/=lib/openzeppelin-contracts/\",\":ds-test/=lib/openzeppelin-contracts/lib/forge-std/lib/ds-test/src/\",\":erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/\",\":forge-std/=lib/openzeppelin-contracts/lib/forge-std/src/\",\":openzeppelin-contracts/=lib/openzeppelin-contracts/\",\"lib/openzeppelin-contracts:openzeppelin/=lib/openzeppelin-contracts/contracts/\"]},\"sources\":{\"lib/openzeppelin-contracts/contracts/access/Ownable.sol\":{\"keccak256\":\"0xba43b97fba0d32eb4254f6a5a297b39a19a247082a02d6e69349e071e2946218\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://fc980984badf3984b6303b377711220e067722bbd6a135b24669ff5069ef9f32\",\"dweb:/ipfs/QmPHXMSXj99XjSVM21YsY6aNtLLjLVXDbyN76J5HQYvvrz\"]},\"lib/openzeppelin-contracts/contracts/utils/Context.sol\":{\"keccak256\":\"0xe2e337e6dde9ef6b680e07338c493ebea1b5fd09b43424112868e9cc1706bca7\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6df0ddf21ce9f58271bdfaa85cde98b200ef242a05a3f85c2bc10a8294800a92\",\"dweb:/ipfs/QmRK2Y5Yc6BK7tGKkgsgn3aJEQGi5aakeSPZvS65PV8Xp3\"]},\"src/FeeRewardsManager.sol\":{\"keccak256\":\"0xee7707562ed88509b24a4afdb11a67e249e370a3cdcaadb4ec07f84e03ed7fee\",\"license\":\"BSD-3-Clause\",\"urls\":[\"bzz-raw://919c541bdc389cb848285b2dea3ae95530b979b4cc38464b7cbbb27a6de72b54\",\"dweb:/ipfs/QmcBL1oHeRKRdrmh8FYBbKkRjAMpgZjyCR46V1yazkLaL4\"]}},\"version\":1}",
+    "metadata": {
+        "compiler": {
+            "version": "0.8.20+commit.a1b79de6"
+        },
+        "language": "Solidity",
+        "output": {
+            "abi": [
+                {
+                    "inputs": [
+                        {
+                            "internalType": "uint32",
+                            "name": "_defaultFeeNumerator",
+                            "type": "uint32"
+                        }
+                    ],
+                    "stateMutability": "nonpayable",
+                    "type": "constructor"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "address",
+                            "name": "contractAddress",
+                            "type": "address",
+                            "indexed": false
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "feeNumerator",
+                            "type": "uint32",
+                            "indexed": false
+                        }
+                    ],
+                    "type": "event",
+                    "name": "ContractDeployed",
+                    "anonymous": false
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "address",
+                            "name": "previousOwner",
+                            "type": "address",
+                            "indexed": true
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "newOwner",
+                            "type": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "type": "event",
+                    "name": "OwnershipTransferred",
+                    "anonymous": false
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "address payable[]",
+                            "name": "feeAddresses",
+                            "type": "address[]"
+                        }
+                    ],
+                    "stateMutability": "nonpayable",
+                    "type": "function",
+                    "name": "batchCollectRewards"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "uint32",
+                            "name": "_newFeeNumerator",
+                            "type": "uint32"
+                        }
+                    ],
+                    "stateMutability": "nonpayable",
+                    "type": "function",
+                    "name": "changeDefaultFee"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "address payable",
+                            "name": "_feeContract",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint32",
+                            "name": "_newFee",
+                            "type": "uint32"
+                        }
+                    ],
+                    "stateMutability": "nonpayable",
+                    "type": "function",
+                    "name": "changeFeeNumerator"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "address",
+                            "name": "_withdrawalCredential",
+                            "type": "address"
+                        }
+                    ],
+                    "stateMutability": "nonpayable",
+                    "type": "function",
+                    "name": "createFeeContract",
+                    "outputs": [
+                        {
+                            "internalType": "address payable",
+                            "name": "",
+                            "type": "address"
+                        }
+                    ]
+                },
+                {
+                    "inputs": [],
+                    "stateMutability": "view",
+                    "type": "function",
+                    "name": "defaultFeeNumerator",
+                    "outputs": [
+                        {
+                            "internalType": "uint32",
+                            "name": "",
+                            "type": "uint32"
+                        }
+                    ]
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "address",
+                            "name": "addr",
+                            "type": "address"
+                        }
+                    ],
+                    "stateMutability": "nonpayable",
+                    "type": "function",
+                    "name": "getEth"
+                },
+                {
+                    "inputs": [],
+                    "stateMutability": "view",
+                    "type": "function",
+                    "name": "owner",
+                    "outputs": [
+                        {
+                            "internalType": "address",
+                            "name": "",
+                            "type": "address"
+                        }
+                    ]
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "address",
+                            "name": "_withdrawalCredential",
+                            "type": "address"
+                        }
+                    ],
+                    "stateMutability": "view",
+                    "type": "function",
+                    "name": "predictFeeContractAddress",
+                    "outputs": [
+                        {
+                            "internalType": "address",
+                            "name": "",
+                            "type": "address"
+                        }
+                    ]
+                },
+                {
+                    "inputs": [],
+                    "stateMutability": "nonpayable",
+                    "type": "function",
+                    "name": "renounceOwnership"
+                },
+                {
+                    "inputs": [
+                        {
+                            "internalType": "address",
+                            "name": "newOwner",
+                            "type": "address"
+                        }
+                    ],
+                    "stateMutability": "nonpayable",
+                    "type": "function",
+                    "name": "transferOwnership"
+                },
+                {
+                    "inputs": [],
+                    "stateMutability": "payable",
+                    "type": "receive"
+                }
+            ],
+            "devdoc": {
+                "kind": "dev",
+                "methods": {
+                    "owner()": {
+                        "details": "Returns the address of the current owner."
+                    },
+                    "renounceOwnership()": {
+                        "details": "Leaves the contract without owner. It will not be possible to call `onlyOwner` functions. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby disabling any functionality that is only available to the owner."
+                    },
+                    "transferOwnership(address)": {
+                        "details": "Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner."
+                    }
+                },
+                "version": 1
+            },
+            "userdoc": {
+                "kind": "user",
+                "methods": {},
+                "version": 1
+            }
+        },
+        "settings": {
+            "remappings": [
+                "@openzeppelin/=lib/openzeppelin-contracts/",
+                "ds-test/=lib/openzeppelin-contracts/lib/forge-std/lib/ds-test/src/",
+                "erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/",
+                "forge-std/=lib/openzeppelin-contracts/lib/forge-std/src/",
+                "openzeppelin-contracts/=lib/openzeppelin-contracts/",
+                "lib/openzeppelin-contracts:openzeppelin/=lib/openzeppelin-contracts/contracts/"
+            ],
+            "optimizer": {
+                "enabled": true,
+                "runs": 200
+            },
+            "metadata": {
+                "bytecodeHash": "ipfs"
+            },
+            "compilationTarget": {
+                "src/FeeRewardsManager.sol": "FeeRewardsManager"
+            },
+            "libraries": {}
+        },
+        "sources": {
+            "lib/openzeppelin-contracts/contracts/access/Ownable.sol": {
+                "keccak256": "0xba43b97fba0d32eb4254f6a5a297b39a19a247082a02d6e69349e071e2946218",
+                "urls": [
+                    "bzz-raw://fc980984badf3984b6303b377711220e067722bbd6a135b24669ff5069ef9f32",
+                    "dweb:/ipfs/QmPHXMSXj99XjSVM21YsY6aNtLLjLVXDbyN76J5HQYvvrz"
+                ],
+                "license": "MIT"
+            },
+            "lib/openzeppelin-contracts/contracts/utils/Context.sol": {
+                "keccak256": "0xe2e337e6dde9ef6b680e07338c493ebea1b5fd09b43424112868e9cc1706bca7",
+                "urls": [
+                    "bzz-raw://6df0ddf21ce9f58271bdfaa85cde98b200ef242a05a3f85c2bc10a8294800a92",
+                    "dweb:/ipfs/QmRK2Y5Yc6BK7tGKkgsgn3aJEQGi5aakeSPZvS65PV8Xp3"
+                ],
+                "license": "MIT"
+            },
+            "src/FeeRewardsManager.sol": {
+                "keccak256": "0xee7707562ed88509b24a4afdb11a67e249e370a3cdcaadb4ec07f84e03ed7fee",
+                "urls": [
+                    "bzz-raw://919c541bdc389cb848285b2dea3ae95530b979b4cc38464b7cbbb27a6de72b54",
+                    "dweb:/ipfs/QmcBL1oHeRKRdrmh8FYBbKkRjAMpgZjyCR46V1yazkLaL4"
+                ],
+                "license": "BSD-3-Clause"
+            }
+        },
+        "version": 1
+    },
+    "ast": {
+        "absolutePath": "src/FeeRewardsManager.sol",
+        "id": 28869,
+        "exportedSymbols": {
+            "CalculateAndSendRewards": [
+                28588
+            ],
+            "Context": [
+                134
+            ],
+            "FeeRewardsManager": [
+                28868
+            ],
+            "Ownable": [
+                112
+            ],
+            "RewardsCollector": [
+                28650
+            ]
+        },
+        "nodeType": "SourceUnit",
+        "src": "41:5509:19",
+        "nodes": [
+            {
+                "id": 28497,
+                "nodeType": "PragmaDirective",
+                "src": "41:24:19",
+                "nodes": [],
+                "literals": [
+                    "solidity",
+                    "^",
+                    "0.8",
+                    ".13"
+                ]
+            },
+            {
+                "id": 28498,
+                "nodeType": "ImportDirective",
+                "src": "67:52:19",
+                "nodes": [],
+                "absolutePath": "lib/openzeppelin-contracts/contracts/access/Ownable.sol",
+                "file": "@openzeppelin/contracts/access/Ownable.sol",
+                "nameLocation": "-1:-1:-1",
+                "scope": 28869,
+                "sourceUnit": 113,
+                "symbolAliases": [],
+                "unitAlias": ""
+            },
+            {
+                "id": 28588,
+                "nodeType": "ContractDefinition",
+                "src": "370:1280:19",
+                "nodes": [
+                    {
+                        "id": 28501,
+                        "nodeType": "VariableDeclaration",
+                        "src": "499:46:19",
+                        "nodes": [],
+                        "constant": true,
+                        "functionSelector": "d73792a9",
+                        "mutability": "constant",
+                        "name": "FEE_DENOMINATOR",
+                        "nameLocation": "522:15:19",
+                        "scope": 28588,
+                        "stateVariable": true,
+                        "storageLocation": "default",
+                        "typeDescriptions": {
+                            "typeIdentifier": "t_uint32",
+                            "typeString": "uint32"
+                        },
+                        "typeName": {
+                            "id": 28499,
+                            "name": "uint32",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "499:6:19",
+                            "typeDescriptions": {
+                                "typeIdentifier": "t_uint32",
+                                "typeString": "uint32"
+                            }
+                        },
+                        "value": {
+                            "hexValue": "3130303030",
+                            "id": 28500,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "kind": "number",
+                            "lValueRequested": false,
+                            "nodeType": "Literal",
+                            "src": "540:5:19",
+                            "typeDescriptions": {
+                                "typeIdentifier": "t_rational_10000_by_1",
+                                "typeString": "int_const 10000"
+                            },
+                            "value": "10000"
+                        },
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28511,
+                        "nodeType": "EventDefinition",
+                        "src": "551:148:19",
+                        "nodes": [],
+                        "anonymous": false,
+                        "eventSelector": "ea26d65e718d9960bf3d074b264a29f878be92f11e3a4f1b5ab8e81038cc1fc0",
+                        "name": "CollectedReward",
+                        "nameLocation": "557:15:19",
+                        "parameters": {
+                            "id": 28510,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28503,
+                                    "indexed": false,
+                                    "mutability": "mutable",
+                                    "name": "withdrawalCredential",
+                                    "nameLocation": "590:20:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28511,
+                                    "src": "582:28:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28502,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "582:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                },
+                                {
+                                    "constant": false,
+                                    "id": 28505,
+                                    "indexed": false,
+                                    "mutability": "mutable",
+                                    "name": "withdrawnAmount",
+                                    "nameLocation": "628:15:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28511,
+                                    "src": "620:23:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_uint256",
+                                        "typeString": "uint256"
+                                    },
+                                    "typeName": {
+                                        "id": 28504,
+                                        "name": "uint256",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "620:7:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint256",
+                                            "typeString": "uint256"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                },
+                                {
+                                    "constant": false,
+                                    "id": 28507,
+                                    "indexed": false,
+                                    "mutability": "mutable",
+                                    "name": "owner",
+                                    "nameLocation": "661:5:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28511,
+                                    "src": "653:13:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28506,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "653:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                },
+                                {
+                                    "constant": false,
+                                    "id": 28509,
+                                    "indexed": false,
+                                    "mutability": "mutable",
+                                    "name": "ownerFee",
+                                    "nameLocation": "684:8:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28511,
+                                    "src": "676:16:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_uint256",
+                                        "typeString": "uint256"
+                                    },
+                                    "typeName": {
+                                        "id": 28508,
+                                        "name": "uint256",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "676:7:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint256",
+                                            "typeString": "uint256"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "572:126:19"
+                        }
+                    },
+                    {
+                        "id": 28587,
+                        "nodeType": "FunctionDefinition",
+                        "src": "705:943:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28586,
+                            "nodeType": "Block",
+                            "src": "834:814:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "assignments": [
+                                        28521
+                                    ],
+                                    "declarations": [
+                                        {
+                                            "constant": false,
+                                            "id": 28521,
+                                            "mutability": "mutable",
+                                            "name": "ownerAmount",
+                                            "nameLocation": "852:11:19",
+                                            "nodeType": "VariableDeclaration",
+                                            "scope": 28586,
+                                            "src": "844:19:19",
+                                            "stateVariable": false,
+                                            "storageLocation": "default",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint256",
+                                                "typeString": "uint256"
+                                            },
+                                            "typeName": {
+                                                "id": 28520,
+                                                "name": "uint256",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "844:7:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            },
+                                            "visibility": "internal"
+                                        }
+                                    ],
+                                    "id": 28532,
+                                    "initialValue": {
+                                        "commonType": {
+                                            "typeIdentifier": "t_uint256",
+                                            "typeString": "uint256"
+                                        },
+                                        "id": 28531,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftExpression": {
+                                            "components": [
+                                                {
+                                                    "commonType": {
+                                                        "typeIdentifier": "t_uint256",
+                                                        "typeString": "uint256"
+                                                    },
+                                                    "id": 28528,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": false,
+                                                    "lValueRequested": false,
+                                                    "leftExpression": {
+                                                        "expression": {
+                                                            "arguments": [
+                                                                {
+                                                                    "id": 28524,
+                                                                    "name": "this",
+                                                                    "nodeType": "Identifier",
+                                                                    "overloadedDeclarations": [],
+                                                                    "referencedDeclaration": -28,
+                                                                    "src": "875:4:19",
+                                                                    "typeDescriptions": {
+                                                                        "typeIdentifier": "t_contract$_CalculateAndSendRewards_$28588",
+                                                                        "typeString": "library CalculateAndSendRewards"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "expression": {
+                                                                "argumentTypes": [
+                                                                    {
+                                                                        "typeIdentifier": "t_contract$_CalculateAndSendRewards_$28588",
+                                                                        "typeString": "library CalculateAndSendRewards"
+                                                                    }
+                                                                ],
+                                                                "id": 28523,
+                                                                "isConstant": false,
+                                                                "isLValue": false,
+                                                                "isPure": true,
+                                                                "lValueRequested": false,
+                                                                "nodeType": "ElementaryTypeNameExpression",
+                                                                "src": "867:7:19",
+                                                                "typeDescriptions": {
+                                                                    "typeIdentifier": "t_type$_t_address_$",
+                                                                    "typeString": "type(address)"
+                                                                },
+                                                                "typeName": {
+                                                                    "id": 28522,
+                                                                    "name": "address",
+                                                                    "nodeType": "ElementaryTypeName",
+                                                                    "src": "867:7:19",
+                                                                    "typeDescriptions": {}
+                                                                }
+                                                            },
+                                                            "id": 28525,
+                                                            "isConstant": false,
+                                                            "isLValue": false,
+                                                            "isPure": false,
+                                                            "kind": "typeConversion",
+                                                            "lValueRequested": false,
+                                                            "nameLocations": [],
+                                                            "names": [],
+                                                            "nodeType": "FunctionCall",
+                                                            "src": "867:13:19",
+                                                            "tryCall": false,
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_address",
+                                                                "typeString": "address"
+                                                            }
+                                                        },
+                                                        "id": 28526,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": false,
+                                                        "lValueRequested": false,
+                                                        "memberLocation": "881:7:19",
+                                                        "memberName": "balance",
+                                                        "nodeType": "MemberAccess",
+                                                        "src": "867:21:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_uint256",
+                                                            "typeString": "uint256"
+                                                        }
+                                                    },
+                                                    "nodeType": "BinaryOperation",
+                                                    "operator": "*",
+                                                    "rightExpression": {
+                                                        "id": 28527,
+                                                        "name": "feeNominator",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 28513,
+                                                        "src": "891:12:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_uint32",
+                                                            "typeString": "uint32"
+                                                        }
+                                                    },
+                                                    "src": "867:36:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_uint256",
+                                                        "typeString": "uint256"
+                                                    }
+                                                }
+                                            ],
+                                            "id": 28529,
+                                            "isConstant": false,
+                                            "isInlineArray": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "nodeType": "TupleExpression",
+                                            "src": "866:38:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint256",
+                                                "typeString": "uint256"
+                                            }
+                                        },
+                                        "nodeType": "BinaryOperation",
+                                        "operator": "/",
+                                        "rightExpression": {
+                                            "id": 28530,
+                                            "name": "FEE_DENOMINATOR",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28501,
+                                            "src": "919:15:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "src": "866:68:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint256",
+                                            "typeString": "uint256"
+                                        }
+                                    },
+                                    "nodeType": "VariableDeclarationStatement",
+                                    "src": "844:90:19"
+                                },
+                                {
+                                    "assignments": [
+                                        28534
+                                    ],
+                                    "declarations": [
+                                        {
+                                            "constant": false,
+                                            "id": 28534,
+                                            "mutability": "mutable",
+                                            "name": "returnedAmount",
+                                            "nameLocation": "952:14:19",
+                                            "nodeType": "VariableDeclaration",
+                                            "scope": 28586,
+                                            "src": "944:22:19",
+                                            "stateVariable": false,
+                                            "storageLocation": "default",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint256",
+                                                "typeString": "uint256"
+                                            },
+                                            "typeName": {
+                                                "id": 28533,
+                                                "name": "uint256",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "944:7:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            },
+                                            "visibility": "internal"
+                                        }
+                                    ],
+                                    "id": 28542,
+                                    "initialValue": {
+                                        "commonType": {
+                                            "typeIdentifier": "t_uint256",
+                                            "typeString": "uint256"
+                                        },
+                                        "id": 28541,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftExpression": {
+                                            "expression": {
+                                                "arguments": [
+                                                    {
+                                                        "id": 28537,
+                                                        "name": "this",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": -28,
+                                                        "src": "977:4:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_contract$_CalculateAndSendRewards_$28588",
+                                                            "typeString": "library CalculateAndSendRewards"
+                                                        }
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "argumentTypes": [
+                                                        {
+                                                            "typeIdentifier": "t_contract$_CalculateAndSendRewards_$28588",
+                                                            "typeString": "library CalculateAndSendRewards"
+                                                        }
+                                                    ],
+                                                    "id": 28536,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": true,
+                                                    "lValueRequested": false,
+                                                    "nodeType": "ElementaryTypeNameExpression",
+                                                    "src": "969:7:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_type$_t_address_$",
+                                                        "typeString": "type(address)"
+                                                    },
+                                                    "typeName": {
+                                                        "id": 28535,
+                                                        "name": "address",
+                                                        "nodeType": "ElementaryTypeName",
+                                                        "src": "969:7:19",
+                                                        "typeDescriptions": {}
+                                                    }
+                                                },
+                                                "id": 28538,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "kind": "typeConversion",
+                                                "lValueRequested": false,
+                                                "nameLocations": [],
+                                                "names": [],
+                                                "nodeType": "FunctionCall",
+                                                "src": "969:13:19",
+                                                "tryCall": false,
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            },
+                                            "id": 28539,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "memberLocation": "983:7:19",
+                                            "memberName": "balance",
+                                            "nodeType": "MemberAccess",
+                                            "src": "969:21:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint256",
+                                                "typeString": "uint256"
+                                            }
+                                        },
+                                        "nodeType": "BinaryOperation",
+                                        "operator": "-",
+                                        "rightExpression": {
+                                            "id": 28540,
+                                            "name": "ownerAmount",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28521,
+                                            "src": "993:11:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint256",
+                                                "typeString": "uint256"
+                                            }
+                                        },
+                                        "src": "969:35:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint256",
+                                            "typeString": "uint256"
+                                        }
+                                    },
+                                    "nodeType": "VariableDeclarationStatement",
+                                    "src": "944:60:19"
+                                },
+                                {
+                                    "expression": {
+                                        "arguments": [
+                                            {
+                                                "commonType": {
+                                                    "typeIdentifier": "t_bool",
+                                                    "typeString": "bool"
+                                                },
+                                                "id": 28550,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "lValueRequested": false,
+                                                "leftExpression": {
+                                                    "commonType": {
+                                                        "typeIdentifier": "t_uint256",
+                                                        "typeString": "uint256"
+                                                    },
+                                                    "id": 28546,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": false,
+                                                    "lValueRequested": false,
+                                                    "leftExpression": {
+                                                        "id": 28544,
+                                                        "name": "ownerAmount",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 28521,
+                                                        "src": "1035:11:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_uint256",
+                                                            "typeString": "uint256"
+                                                        }
+                                                    },
+                                                    "nodeType": "BinaryOperation",
+                                                    "operator": "!=",
+                                                    "rightExpression": {
+                                                        "hexValue": "30",
+                                                        "id": 28545,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": true,
+                                                        "kind": "number",
+                                                        "lValueRequested": false,
+                                                        "nodeType": "Literal",
+                                                        "src": "1050:1:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_rational_0_by_1",
+                                                            "typeString": "int_const 0"
+                                                        },
+                                                        "value": "0"
+                                                    },
+                                                    "src": "1035:16:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_bool",
+                                                        "typeString": "bool"
+                                                    }
+                                                },
+                                                "nodeType": "BinaryOperation",
+                                                "operator": "||",
+                                                "rightExpression": {
+                                                    "commonType": {
+                                                        "typeIdentifier": "t_uint256",
+                                                        "typeString": "uint256"
+                                                    },
+                                                    "id": 28549,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": false,
+                                                    "lValueRequested": false,
+                                                    "leftExpression": {
+                                                        "id": 28547,
+                                                        "name": "returnedAmount",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 28534,
+                                                        "src": "1055:14:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_uint256",
+                                                            "typeString": "uint256"
+                                                        }
+                                                    },
+                                                    "nodeType": "BinaryOperation",
+                                                    "operator": "!=",
+                                                    "rightExpression": {
+                                                        "hexValue": "30",
+                                                        "id": 28548,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": true,
+                                                        "kind": "number",
+                                                        "lValueRequested": false,
+                                                        "nodeType": "Literal",
+                                                        "src": "1073:1:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_rational_0_by_1",
+                                                            "typeString": "int_const 0"
+                                                        },
+                                                        "value": "0"
+                                                    },
+                                                    "src": "1055:19:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_bool",
+                                                        "typeString": "bool"
+                                                    }
+                                                },
+                                                "src": "1035:39:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_bool",
+                                                    "typeString": "bool"
+                                                }
+                                            },
+                                            {
+                                                "hexValue": "4e6f7468696e6720746f2064697374726962757465",
+                                                "id": 28551,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": true,
+                                                "kind": "string",
+                                                "lValueRequested": false,
+                                                "nodeType": "Literal",
+                                                "src": "1088:23:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_stringliteral_d842f201acf40e4a9c5acce2e04563f7270e91457322da48af841f8dba899054",
+                                                    "typeString": "literal_string \"Nothing to distribute\""
+                                                },
+                                                "value": "Nothing to distribute"
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_bool",
+                                                    "typeString": "bool"
+                                                },
+                                                {
+                                                    "typeIdentifier": "t_stringliteral_d842f201acf40e4a9c5acce2e04563f7270e91457322da48af841f8dba899054",
+                                                    "typeString": "literal_string \"Nothing to distribute\""
+                                                }
+                                            ],
+                                            "id": 28543,
+                                            "name": "require",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [
+                                                -18,
+                                                -18
+                                            ],
+                                            "referencedDeclaration": -18,
+                                            "src": "1014:7:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                                                "typeString": "function (bool,string memory) pure"
+                                            }
+                                        },
+                                        "id": 28552,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "1014:107:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$__$",
+                                            "typeString": "tuple()"
+                                        }
+                                    },
+                                    "id": 28553,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "1014:107:19"
+                                },
+                                {
+                                    "eventCall": {
+                                        "arguments": [
+                                            {
+                                                "id": 28555,
+                                                "name": "withdrawalCredential",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28517,
+                                                "src": "1165:20:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            },
+                                            {
+                                                "id": 28556,
+                                                "name": "returnedAmount",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28534,
+                                                "src": "1199:14:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            },
+                                            {
+                                                "id": 28557,
+                                                "name": "owner",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28515,
+                                                "src": "1227:5:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            },
+                                            {
+                                                "id": 28558,
+                                                "name": "ownerAmount",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28521,
+                                                "src": "1246:11:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                },
+                                                {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                },
+                                                {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                },
+                                                {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            ],
+                                            "id": 28554,
+                                            "name": "CollectedReward",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28511,
+                                            "src": "1136:15:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint256_$_t_address_$_t_uint256_$returns$__$",
+                                                "typeString": "function (address,uint256,address,uint256)"
+                                            }
+                                        },
+                                        "id": 28559,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "1136:131:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$__$",
+                                            "typeString": "tuple()"
+                                        }
+                                    },
+                                    "id": 28560,
+                                    "nodeType": "EmitStatement",
+                                    "src": "1131:136:19"
+                                },
+                                {
+                                    "expression": {
+                                        "arguments": [
+                                            {
+                                                "id": 28566,
+                                                "name": "ownerAmount",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28521,
+                                                "src": "1443:11:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            ],
+                                            "expression": {
+                                                "arguments": [
+                                                    {
+                                                        "id": 28563,
+                                                        "name": "owner",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 28515,
+                                                        "src": "1427:5:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_address",
+                                                            "typeString": "address"
+                                                        }
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "argumentTypes": [
+                                                        {
+                                                            "typeIdentifier": "t_address",
+                                                            "typeString": "address"
+                                                        }
+                                                    ],
+                                                    "id": 28562,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": true,
+                                                    "lValueRequested": false,
+                                                    "nodeType": "ElementaryTypeNameExpression",
+                                                    "src": "1419:8:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_type$_t_address_payable_$",
+                                                        "typeString": "type(address payable)"
+                                                    },
+                                                    "typeName": {
+                                                        "id": 28561,
+                                                        "name": "address",
+                                                        "nodeType": "ElementaryTypeName",
+                                                        "src": "1419:8:19",
+                                                        "stateMutability": "payable",
+                                                        "typeDescriptions": {}
+                                                    }
+                                                },
+                                                "id": 28564,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "kind": "typeConversion",
+                                                "lValueRequested": false,
+                                                "nameLocations": [],
+                                                "names": [],
+                                                "nodeType": "FunctionCall",
+                                                "src": "1419:14:19",
+                                                "tryCall": false,
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address_payable",
+                                                    "typeString": "address payable"
+                                                }
+                                            },
+                                            "id": 28565,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "memberLocation": "1434:8:19",
+                                            "memberName": "transfer",
+                                            "nodeType": "MemberAccess",
+                                            "src": "1419:23:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_transfer_nonpayable$_t_uint256_$returns$__$",
+                                                "typeString": "function (uint256)"
+                                            }
+                                        },
+                                        "id": 28567,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "1419:36:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$__$",
+                                            "typeString": "tuple()"
+                                        }
+                                    },
+                                    "id": 28568,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "1419:36:19"
+                                },
+                                {
+                                    "assignments": [
+                                        28570,
+                                        null
+                                    ],
+                                    "declarations": [
+                                        {
+                                            "constant": false,
+                                            "id": 28570,
+                                            "mutability": "mutable",
+                                            "name": "sent",
+                                            "nameLocation": "1471:4:19",
+                                            "nodeType": "VariableDeclaration",
+                                            "scope": 28586,
+                                            "src": "1466:9:19",
+                                            "stateVariable": false,
+                                            "storageLocation": "default",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_bool",
+                                                "typeString": "bool"
+                                            },
+                                            "typeName": {
+                                                "id": 28569,
+                                                "name": "bool",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "1466:4:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_bool",
+                                                    "typeString": "bool"
+                                                }
+                                            },
+                                            "visibility": "internal"
+                                        },
+                                        null
+                                    ],
+                                    "id": 28580,
+                                    "initialValue": {
+                                        "arguments": [
+                                            {
+                                                "hexValue": "",
+                                                "id": 28578,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": true,
+                                                "kind": "string",
+                                                "lValueRequested": false,
+                                                "nodeType": "Literal",
+                                                "src": "1561:2:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_stringliteral_c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+                                                    "typeString": "literal_string \"\""
+                                                },
+                                                "value": ""
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_stringliteral_c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+                                                    "typeString": "literal_string \"\""
+                                                }
+                                            ],
+                                            "expression": {
+                                                "argumentTypes": [
+                                                    {
+                                                        "typeIdentifier": "t_stringliteral_c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+                                                        "typeString": "literal_string \"\""
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "arguments": [
+                                                        {
+                                                            "id": 28573,
+                                                            "name": "withdrawalCredential",
+                                                            "nodeType": "Identifier",
+                                                            "overloadedDeclarations": [],
+                                                            "referencedDeclaration": 28517,
+                                                            "src": "1489:20:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_address",
+                                                                "typeString": "address"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "expression": {
+                                                        "argumentTypes": [
+                                                            {
+                                                                "typeIdentifier": "t_address",
+                                                                "typeString": "address"
+                                                            }
+                                                        ],
+                                                        "id": 28572,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": true,
+                                                        "lValueRequested": false,
+                                                        "nodeType": "ElementaryTypeNameExpression",
+                                                        "src": "1481:8:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_type$_t_address_payable_$",
+                                                            "typeString": "type(address payable)"
+                                                        },
+                                                        "typeName": {
+                                                            "id": 28571,
+                                                            "name": "address",
+                                                            "nodeType": "ElementaryTypeName",
+                                                            "src": "1481:8:19",
+                                                            "stateMutability": "payable",
+                                                            "typeDescriptions": {}
+                                                        }
+                                                    },
+                                                    "id": 28574,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": false,
+                                                    "kind": "typeConversion",
+                                                    "lValueRequested": false,
+                                                    "nameLocations": [],
+                                                    "names": [],
+                                                    "nodeType": "FunctionCall",
+                                                    "src": "1481:29:19",
+                                                    "tryCall": false,
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_address_payable",
+                                                        "typeString": "address payable"
+                                                    }
+                                                },
+                                                "id": 28575,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "lValueRequested": false,
+                                                "memberLocation": "1511:4:19",
+                                                "memberName": "call",
+                                                "nodeType": "MemberAccess",
+                                                "src": "1481:34:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_function_barecall_payable$_t_bytes_memory_ptr_$returns$_t_bool_$_t_bytes_memory_ptr_$",
+                                                    "typeString": "function (bytes memory) payable returns (bool,bytes memory)"
+                                                }
+                                            },
+                                            "id": 28577,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "names": [
+                                                "value"
+                                            ],
+                                            "nodeType": "FunctionCallOptions",
+                                            "options": [
+                                                {
+                                                    "id": 28576,
+                                                    "name": "returnedAmount",
+                                                    "nodeType": "Identifier",
+                                                    "overloadedDeclarations": [],
+                                                    "referencedDeclaration": 28534,
+                                                    "src": "1536:14:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_uint256",
+                                                        "typeString": "uint256"
+                                                    }
+                                                }
+                                            ],
+                                            "src": "1481:79:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_barecall_payable$_t_bytes_memory_ptr_$returns$_t_bool_$_t_bytes_memory_ptr_$value",
+                                                "typeString": "function (bytes memory) payable returns (bool,bytes memory)"
+                                            }
+                                        },
+                                        "id": 28579,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "1481:83:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$_t_bool_$_t_bytes_memory_ptr_$",
+                                            "typeString": "tuple(bool,bytes memory)"
+                                        }
+                                    },
+                                    "nodeType": "VariableDeclarationStatement",
+                                    "src": "1465:99:19"
+                                },
+                                {
+                                    "expression": {
+                                        "arguments": [
+                                            {
+                                                "id": 28582,
+                                                "name": "sent",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28570,
+                                                "src": "1582:4:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_bool",
+                                                    "typeString": "bool"
+                                                }
+                                            },
+                                            {
+                                                "hexValue": "4661696c656420746f2073656e64204574686572206261636b20746f207769746864726177616c2063726564656e7469616c",
+                                                "id": 28583,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": true,
+                                                "kind": "string",
+                                                "lValueRequested": false,
+                                                "nodeType": "Literal",
+                                                "src": "1588:52:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_stringliteral_6ccf786fc3618692ee3b7a0f19c9a459b50c544b1291a2feb85a687148f1638e",
+                                                    "typeString": "literal_string \"Failed to send Ether back to withdrawal credential\""
+                                                },
+                                                "value": "Failed to send Ether back to withdrawal credential"
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_bool",
+                                                    "typeString": "bool"
+                                                },
+                                                {
+                                                    "typeIdentifier": "t_stringliteral_6ccf786fc3618692ee3b7a0f19c9a459b50c544b1291a2feb85a687148f1638e",
+                                                    "typeString": "literal_string \"Failed to send Ether back to withdrawal credential\""
+                                                }
+                                            ],
+                                            "id": 28581,
+                                            "name": "require",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [
+                                                -18,
+                                                -18
+                                            ],
+                                            "referencedDeclaration": -18,
+                                            "src": "1574:7:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                                                "typeString": "function (bool,string memory) pure"
+                                            }
+                                        },
+                                        "id": 28584,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "1574:67:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$__$",
+                                            "typeString": "tuple()"
+                                        }
+                                    },
+                                    "id": 28585,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "1574:67:19"
+                                }
+                            ]
+                        },
+                        "functionSelector": "ea788f43",
+                        "implemented": true,
+                        "kind": "function",
+                        "modifiers": [],
+                        "name": "calculateRewards",
+                        "nameLocation": "714:16:19",
+                        "parameters": {
+                            "id": 28518,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28513,
+                                    "mutability": "mutable",
+                                    "name": "feeNominator",
+                                    "nameLocation": "747:12:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28587,
+                                    "src": "740:19:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_uint32",
+                                        "typeString": "uint32"
+                                    },
+                                    "typeName": {
+                                        "id": 28512,
+                                        "name": "uint32",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "740:6:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                },
+                                {
+                                    "constant": false,
+                                    "id": 28515,
+                                    "mutability": "mutable",
+                                    "name": "owner",
+                                    "nameLocation": "777:5:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28587,
+                                    "src": "769:13:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28514,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "769:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                },
+                                {
+                                    "constant": false,
+                                    "id": 28517,
+                                    "mutability": "mutable",
+                                    "name": "withdrawalCredential",
+                                    "nameLocation": "800:20:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28587,
+                                    "src": "792:28:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28516,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "792:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "730:96:19"
+                        },
+                        "returnParameters": {
+                            "id": 28519,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "834:0:19"
+                        },
+                        "scope": 28588,
+                        "stateMutability": "nonpayable",
+                        "virtual": false,
+                        "visibility": "public"
+                    }
+                ],
+                "abstract": false,
+                "baseContracts": [],
+                "canonicalName": "CalculateAndSendRewards",
+                "contractDependencies": [],
+                "contractKind": "library",
+                "fullyImplemented": true,
+                "linearizedBaseContracts": [
+                    28588
+                ],
+                "name": "CalculateAndSendRewards",
+                "nameLocation": "378:23:19",
+                "scope": 28869,
+                "usedErrors": [],
+                "usedEvents": [
+                    28511
+                ]
+            },
+            {
+                "id": 28650,
+                "nodeType": "ContractDefinition",
+                "src": "1652:1234:19",
+                "nodes": [
+                    {
+                        "id": 28590,
+                        "nodeType": "VariableDeclaration",
+                        "src": "1738:35:19",
+                        "nodes": [],
+                        "constant": false,
+                        "functionSelector": "83059303",
+                        "mutability": "mutable",
+                        "name": "withdrawalCredential",
+                        "nameLocation": "1753:20:19",
+                        "scope": 28650,
+                        "stateVariable": true,
+                        "storageLocation": "default",
+                        "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                        },
+                        "typeName": {
+                            "id": 28589,
+                            "name": "address",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "1738:7:19",
+                            "stateMutability": "nonpayable",
+                            "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                            }
+                        },
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28592,
+                        "nodeType": "VariableDeclaration",
+                        "src": "1804:26:19",
+                        "nodes": [],
+                        "constant": false,
+                        "functionSelector": "e86dea4a",
+                        "mutability": "mutable",
+                        "name": "feeNumerator",
+                        "nameLocation": "1818:12:19",
+                        "scope": 28650,
+                        "stateVariable": true,
+                        "storageLocation": "default",
+                        "typeDescriptions": {
+                            "typeIdentifier": "t_uint32",
+                            "typeString": "uint32"
+                        },
+                        "typeName": {
+                            "id": 28591,
+                            "name": "uint32",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "1804:6:19",
+                            "typeDescriptions": {
+                                "typeIdentifier": "t_uint32",
+                                "typeString": "uint32"
+                            }
+                        },
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28594,
+                        "nodeType": "VariableDeclaration",
+                        "src": "2124:29:19",
+                        "nodes": [],
+                        "constant": false,
+                        "functionSelector": "230b9da3",
+                        "mutability": "mutable",
+                        "name": "parentContract",
+                        "nameLocation": "2139:14:19",
+                        "scope": 28650,
+                        "stateVariable": true,
+                        "storageLocation": "default",
+                        "typeDescriptions": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                        },
+                        "typeName": {
+                            "id": 28593,
+                            "name": "address",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "2124:7:19",
+                            "stateMutability": "nonpayable",
+                            "typeDescriptions": {
+                                "typeIdentifier": "t_address",
+                                "typeString": "address"
+                            }
+                        },
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28598,
+                        "nodeType": "FunctionDefinition",
+                        "src": "2206:29:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28597,
+                            "nodeType": "Block",
+                            "src": "2233:2:19",
+                            "nodes": [],
+                            "statements": []
+                        },
+                        "implemented": true,
+                        "kind": "receive",
+                        "modifiers": [],
+                        "name": "",
+                        "nameLocation": "-1:-1:-1",
+                        "parameters": {
+                            "id": 28595,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "2213:2:19"
+                        },
+                        "returnParameters": {
+                            "id": 28596,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "2233:0:19"
+                        },
+                        "scope": 28650,
+                        "stateMutability": "payable",
+                        "virtual": false,
+                        "visibility": "external"
+                    },
+                    {
+                        "id": 28610,
+                        "nodeType": "FunctionDefinition",
+                        "src": "2241:196:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28609,
+                            "nodeType": "Block",
+                            "src": "2282:155:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "expression": {
+                                        "arguments": [
+                                            {
+                                                "id": 28604,
+                                                "name": "feeNumerator",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28592,
+                                                "src": "2346:12:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint32",
+                                                    "typeString": "uint32"
+                                                }
+                                            },
+                                            {
+                                                "id": 28605,
+                                                "name": "parentContract",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28594,
+                                                "src": "2372:14:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            },
+                                            {
+                                                "id": 28606,
+                                                "name": "withdrawalCredential",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28590,
+                                                "src": "2400:20:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_uint32",
+                                                    "typeString": "uint32"
+                                                },
+                                                {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                },
+                                                {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            ],
+                                            "expression": {
+                                                "id": 28601,
+                                                "name": "CalculateAndSendRewards",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28588,
+                                                "src": "2292:23:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_type$_t_contract$_CalculateAndSendRewards_$28588_$",
+                                                    "typeString": "type(library CalculateAndSendRewards)"
+                                                }
+                                            },
+                                            "id": 28603,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "memberLocation": "2316:16:19",
+                                            "memberName": "calculateRewards",
+                                            "nodeType": "MemberAccess",
+                                            "referencedDeclaration": 28587,
+                                            "src": "2292:40:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_delegatecall_nonpayable$_t_uint32_$_t_address_$_t_address_$returns$__$",
+                                                "typeString": "function (uint32,address,address)"
+                                            }
+                                        },
+                                        "id": 28607,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "2292:138:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$__$",
+                                            "typeString": "tuple()"
+                                        }
+                                    },
+                                    "id": 28608,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "2292:138:19"
+                                }
+                            ]
+                        },
+                        "functionSelector": "70bb45b3",
+                        "implemented": true,
+                        "kind": "function",
+                        "modifiers": [],
+                        "name": "collectRewards",
+                        "nameLocation": "2250:14:19",
+                        "parameters": {
+                            "id": 28599,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "2264:2:19"
+                        },
+                        "returnParameters": {
+                            "id": 28600,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "2282:0:19"
+                        },
+                        "scope": 28650,
+                        "stateMutability": "payable",
+                        "virtual": false,
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28631,
+                        "nodeType": "FunctionDefinition",
+                        "src": "2443:201:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28630,
+                            "nodeType": "Block",
+                            "src": "2508:136:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "expression": {
+                                        "id": 28619,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftHandSide": {
+                                            "id": 28617,
+                                            "name": "withdrawalCredential",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28590,
+                                            "src": "2518:20:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_address",
+                                                "typeString": "address"
+                                            }
+                                        },
+                                        "nodeType": "Assignment",
+                                        "operator": "=",
+                                        "rightHandSide": {
+                                            "id": 28618,
+                                            "name": "_withdrawalCredential",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28612,
+                                            "src": "2541:21:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_address",
+                                                "typeString": "address"
+                                            }
+                                        },
+                                        "src": "2518:44:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "id": 28620,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "2518:44:19"
+                                },
+                                {
+                                    "expression": {
+                                        "id": 28623,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftHandSide": {
+                                            "id": 28621,
+                                            "name": "feeNumerator",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28592,
+                                            "src": "2572:12:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "nodeType": "Assignment",
+                                        "operator": "=",
+                                        "rightHandSide": {
+                                            "id": 28622,
+                                            "name": "_feeNumerator",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28614,
+                                            "src": "2587:13:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "src": "2572:28:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "id": 28624,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "2572:28:19"
+                                },
+                                {
+                                    "expression": {
+                                        "id": 28628,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftHandSide": {
+                                            "id": 28625,
+                                            "name": "parentContract",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28594,
+                                            "src": "2610:14:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_address",
+                                                "typeString": "address"
+                                            }
+                                        },
+                                        "nodeType": "Assignment",
+                                        "operator": "=",
+                                        "rightHandSide": {
+                                            "expression": {
+                                                "id": 28626,
+                                                "name": "msg",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": -15,
+                                                "src": "2627:3:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_magic_message",
+                                                    "typeString": "msg"
+                                                }
+                                            },
+                                            "id": 28627,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "memberLocation": "2631:6:19",
+                                            "memberName": "sender",
+                                            "nodeType": "MemberAccess",
+                                            "src": "2627:10:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_address",
+                                                "typeString": "address"
+                                            }
+                                        },
+                                        "src": "2610:27:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "id": 28629,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "2610:27:19"
+                                }
+                            ]
+                        },
+                        "implemented": true,
+                        "kind": "constructor",
+                        "modifiers": [],
+                        "name": "",
+                        "nameLocation": "-1:-1:-1",
+                        "parameters": {
+                            "id": 28615,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28612,
+                                    "mutability": "mutable",
+                                    "name": "_withdrawalCredential",
+                                    "nameLocation": "2463:21:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28631,
+                                    "src": "2455:29:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28611,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "2455:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                },
+                                {
+                                    "constant": false,
+                                    "id": 28614,
+                                    "mutability": "mutable",
+                                    "name": "_feeNumerator",
+                                    "nameLocation": "2493:13:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28631,
+                                    "src": "2486:20:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_uint32",
+                                        "typeString": "uint32"
+                                    },
+                                    "typeName": {
+                                        "id": 28613,
+                                        "name": "uint32",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "2486:6:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "2454:53:19"
+                        },
+                        "returnParameters": {
+                            "id": 28616,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "2508:0:19"
+                        },
+                        "scope": 28650,
+                        "stateMutability": "nonpayable",
+                        "virtual": false,
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28649,
+                        "nodeType": "FunctionDefinition",
+                        "src": "2650:234:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28648,
+                            "nodeType": "Block",
+                            "src": "2710:174:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "expression": {
+                                        "arguments": [
+                                            {
+                                                "commonType": {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                },
+                                                "id": 28640,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "lValueRequested": false,
+                                                "leftExpression": {
+                                                    "expression": {
+                                                        "id": 28637,
+                                                        "name": "msg",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": -15,
+                                                        "src": "2741:3:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_magic_message",
+                                                            "typeString": "msg"
+                                                        }
+                                                    },
+                                                    "id": 28638,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": false,
+                                                    "lValueRequested": false,
+                                                    "memberLocation": "2745:6:19",
+                                                    "memberName": "sender",
+                                                    "nodeType": "MemberAccess",
+                                                    "src": "2741:10:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_address",
+                                                        "typeString": "address"
+                                                    }
+                                                },
+                                                "nodeType": "BinaryOperation",
+                                                "operator": "==",
+                                                "rightExpression": {
+                                                    "id": 28639,
+                                                    "name": "parentContract",
+                                                    "nodeType": "Identifier",
+                                                    "overloadedDeclarations": [],
+                                                    "referencedDeclaration": 28594,
+                                                    "src": "2755:14:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_address",
+                                                        "typeString": "address"
+                                                    }
+                                                },
+                                                "src": "2741:28:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_bool",
+                                                    "typeString": "bool"
+                                                }
+                                            },
+                                            {
+                                                "hexValue": "4368616e6765466565206e6f742063616c6c65642066726f6d20706172656e7420636f6e7472616374",
+                                                "id": 28641,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": true,
+                                                "kind": "string",
+                                                "lValueRequested": false,
+                                                "nodeType": "Literal",
+                                                "src": "2783:43:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_stringliteral_3ac16390d20fe80ce13231de77b89bac161e164e2dad6197662a09bda86b1722",
+                                                    "typeString": "literal_string \"ChangeFee not called from parent contract\""
+                                                },
+                                                "value": "ChangeFee not called from parent contract"
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_bool",
+                                                    "typeString": "bool"
+                                                },
+                                                {
+                                                    "typeIdentifier": "t_stringliteral_3ac16390d20fe80ce13231de77b89bac161e164e2dad6197662a09bda86b1722",
+                                                    "typeString": "literal_string \"ChangeFee not called from parent contract\""
+                                                }
+                                            ],
+                                            "id": 28636,
+                                            "name": "require",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [
+                                                -18,
+                                                -18
+                                            ],
+                                            "referencedDeclaration": -18,
+                                            "src": "2720:7:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_require_pure$_t_bool_$_t_string_memory_ptr_$returns$__$",
+                                                "typeString": "function (bool,string memory) pure"
+                                            }
+                                        },
+                                        "id": 28642,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "2720:116:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$__$",
+                                            "typeString": "tuple()"
+                                        }
+                                    },
+                                    "id": 28643,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "2720:116:19"
+                                },
+                                {
+                                    "expression": {
+                                        "id": 28646,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftHandSide": {
+                                            "id": 28644,
+                                            "name": "feeNumerator",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28592,
+                                            "src": "2846:12:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "nodeType": "Assignment",
+                                        "operator": "=",
+                                        "rightHandSide": {
+                                            "id": 28645,
+                                            "name": "_newFeeNumerator",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28633,
+                                            "src": "2861:16:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "src": "2846:31:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "id": 28647,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "2846:31:19"
+                                }
+                            ]
+                        },
+                        "functionSelector": "35c84277",
+                        "implemented": true,
+                        "kind": "function",
+                        "modifiers": [],
+                        "name": "changeFeeNumerator",
+                        "nameLocation": "2659:18:19",
+                        "parameters": {
+                            "id": 28634,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28633,
+                                    "mutability": "mutable",
+                                    "name": "_newFeeNumerator",
+                                    "nameLocation": "2685:16:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28649,
+                                    "src": "2678:23:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_uint32",
+                                        "typeString": "uint32"
+                                    },
+                                    "typeName": {
+                                        "id": 28632,
+                                        "name": "uint32",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "2678:6:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "2677:25:19"
+                        },
+                        "returnParameters": {
+                            "id": 28635,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "2710:0:19"
+                        },
+                        "scope": 28650,
+                        "stateMutability": "nonpayable",
+                        "virtual": false,
+                        "visibility": "public"
+                    }
+                ],
+                "abstract": false,
+                "baseContracts": [],
+                "canonicalName": "RewardsCollector",
+                "contractDependencies": [],
+                "contractKind": "contract",
+                "fullyImplemented": true,
+                "linearizedBaseContracts": [
+                    28650
+                ],
+                "name": "RewardsCollector",
+                "nameLocation": "1661:16:19",
+                "scope": 28869,
+                "usedErrors": [],
+                "usedEvents": []
+            },
+            {
+                "id": 28868,
+                "nodeType": "ContractDefinition",
+                "src": "2888:2661:19",
+                "nodes": [
+                    {
+                        "id": 28654,
+                        "nodeType": "VariableDeclaration",
+                        "src": "2932:33:19",
+                        "nodes": [],
+                        "constant": false,
+                        "functionSelector": "af3f6f4d",
+                        "mutability": "mutable",
+                        "name": "defaultFeeNumerator",
+                        "nameLocation": "2946:19:19",
+                        "scope": 28868,
+                        "stateVariable": true,
+                        "storageLocation": "default",
+                        "typeDescriptions": {
+                            "typeIdentifier": "t_uint32",
+                            "typeString": "uint32"
+                        },
+                        "typeName": {
+                            "id": 28653,
+                            "name": "uint32",
+                            "nodeType": "ElementaryTypeName",
+                            "src": "2932:6:19",
+                            "typeDescriptions": {
+                                "typeIdentifier": "t_uint32",
+                                "typeString": "uint32"
+                            }
+                        },
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28664,
+                        "nodeType": "FunctionDefinition",
+                        "src": "2972:100:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28663,
+                            "nodeType": "Block",
+                            "src": "3013:59:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "expression": {
+                                        "id": 28661,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftHandSide": {
+                                            "id": 28659,
+                                            "name": "defaultFeeNumerator",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28654,
+                                            "src": "3023:19:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "nodeType": "Assignment",
+                                        "operator": "=",
+                                        "rightHandSide": {
+                                            "id": 28660,
+                                            "name": "_defaultFeeNumerator",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28656,
+                                            "src": "3045:20:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "src": "3023:42:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "id": 28662,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "3023:42:19"
+                                }
+                            ]
+                        },
+                        "implemented": true,
+                        "kind": "constructor",
+                        "modifiers": [],
+                        "name": "",
+                        "nameLocation": "-1:-1:-1",
+                        "parameters": {
+                            "id": 28657,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28656,
+                                    "mutability": "mutable",
+                                    "name": "_defaultFeeNumerator",
+                                    "nameLocation": "2991:20:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28664,
+                                    "src": "2984:27:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_uint32",
+                                        "typeString": "uint32"
+                                    },
+                                    "typeName": {
+                                        "id": 28655,
+                                        "name": "uint32",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "2984:6:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "2983:29:19"
+                        },
+                        "returnParameters": {
+                            "id": 28658,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "3013:0:19"
+                        },
+                        "scope": 28868,
+                        "stateMutability": "nonpayable",
+                        "virtual": false,
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28670,
+                        "nodeType": "EventDefinition",
+                        "src": "3078:69:19",
+                        "nodes": [],
+                        "anonymous": false,
+                        "eventSelector": "620dca0c9d04f7cea9d7f31e571d74acccd54c21dc8ff8855ec1d5a21733c26b",
+                        "name": "ContractDeployed",
+                        "nameLocation": "3084:16:19",
+                        "parameters": {
+                            "id": 28669,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28666,
+                                    "indexed": false,
+                                    "mutability": "mutable",
+                                    "name": "contractAddress",
+                                    "nameLocation": "3109:15:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28670,
+                                    "src": "3101:23:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28665,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "3101:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                },
+                                {
+                                    "constant": false,
+                                    "id": 28668,
+                                    "indexed": false,
+                                    "mutability": "mutable",
+                                    "name": "feeNumerator",
+                                    "nameLocation": "3133:12:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28670,
+                                    "src": "3126:19:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_uint32",
+                                        "typeString": "uint32"
+                                    },
+                                    "typeName": {
+                                        "id": 28667,
+                                        "name": "uint32",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "3126:6:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "3100:46:19"
+                        }
+                    },
+                    {
+                        "id": 28682,
+                        "nodeType": "FunctionDefinition",
+                        "src": "3153:123:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28681,
+                            "nodeType": "Block",
+                            "src": "3221:55:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "expression": {
+                                        "id": 28679,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftHandSide": {
+                                            "id": 28677,
+                                            "name": "defaultFeeNumerator",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28654,
+                                            "src": "3231:19:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "nodeType": "Assignment",
+                                        "operator": "=",
+                                        "rightHandSide": {
+                                            "id": 28678,
+                                            "name": "_newFeeNumerator",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28672,
+                                            "src": "3253:16:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "src": "3231:38:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "id": 28680,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "3231:38:19"
+                                }
+                            ]
+                        },
+                        "functionSelector": "ef5828d0",
+                        "implemented": true,
+                        "kind": "function",
+                        "modifiers": [
+                            {
+                                "id": 28675,
+                                "kind": "modifierInvocation",
+                                "modifierName": {
+                                    "id": 28674,
+                                    "name": "onlyOwner",
+                                    "nameLocations": [
+                                        "3211:9:19"
+                                    ],
+                                    "nodeType": "IdentifierPath",
+                                    "referencedDeclaration": 31,
+                                    "src": "3211:9:19"
+                                },
+                                "nodeType": "ModifierInvocation",
+                                "src": "3211:9:19"
+                            }
+                        ],
+                        "name": "changeDefaultFee",
+                        "nameLocation": "3162:16:19",
+                        "parameters": {
+                            "id": 28673,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28672,
+                                    "mutability": "mutable",
+                                    "name": "_newFeeNumerator",
+                                    "nameLocation": "3186:16:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28682,
+                                    "src": "3179:23:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_uint32",
+                                        "typeString": "uint32"
+                                    },
+                                    "typeName": {
+                                        "id": 28671,
+                                        "name": "uint32",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "3179:6:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "3178:25:19"
+                        },
+                        "returnParameters": {
+                            "id": 28676,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "3221:0:19"
+                        },
+                        "scope": 28868,
+                        "stateMutability": "nonpayable",
+                        "virtual": false,
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28727,
+                        "nodeType": "FunctionDefinition",
+                        "src": "3282:551:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28726,
+                            "nodeType": "Block",
+                            "src": "3387:446:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "assignments": [
+                                        28690
+                                    ],
+                                    "declarations": [
+                                        {
+                                            "constant": false,
+                                            "id": 28690,
+                                            "mutability": "mutable",
+                                            "name": "withdrawalCredentialBytes",
+                                            "nameLocation": "3405:25:19",
+                                            "nodeType": "VariableDeclaration",
+                                            "scope": 28726,
+                                            "src": "3397:33:19",
+                                            "stateVariable": false,
+                                            "storageLocation": "default",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_bytes32",
+                                                "typeString": "bytes32"
+                                            },
+                                            "typeName": {
+                                                "id": 28689,
+                                                "name": "bytes32",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "3397:7:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_bytes32",
+                                                    "typeString": "bytes32"
+                                                }
+                                            },
+                                            "visibility": "internal"
+                                        }
+                                    ],
+                                    "id": 28701,
+                                    "initialValue": {
+                                        "arguments": [
+                                            {
+                                                "arguments": [
+                                                    {
+                                                        "arguments": [
+                                                            {
+                                                                "id": 28697,
+                                                                "name": "_withdrawalCredential",
+                                                                "nodeType": "Identifier",
+                                                                "overloadedDeclarations": [],
+                                                                "referencedDeclaration": 28684,
+                                                                "src": "3470:21:19",
+                                                                "typeDescriptions": {
+                                                                    "typeIdentifier": "t_address",
+                                                                    "typeString": "address"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "expression": {
+                                                            "argumentTypes": [
+                                                                {
+                                                                    "typeIdentifier": "t_address",
+                                                                    "typeString": "address"
+                                                                }
+                                                            ],
+                                                            "id": 28696,
+                                                            "isConstant": false,
+                                                            "isLValue": false,
+                                                            "isPure": true,
+                                                            "lValueRequested": false,
+                                                            "nodeType": "ElementaryTypeNameExpression",
+                                                            "src": "3462:7:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_type$_t_uint160_$",
+                                                                "typeString": "type(uint160)"
+                                                            },
+                                                            "typeName": {
+                                                                "id": 28695,
+                                                                "name": "uint160",
+                                                                "nodeType": "ElementaryTypeName",
+                                                                "src": "3462:7:19",
+                                                                "typeDescriptions": {}
+                                                            }
+                                                        },
+                                                        "id": 28698,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": false,
+                                                        "kind": "typeConversion",
+                                                        "lValueRequested": false,
+                                                        "nameLocations": [],
+                                                        "names": [],
+                                                        "nodeType": "FunctionCall",
+                                                        "src": "3462:30:19",
+                                                        "tryCall": false,
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_uint160",
+                                                            "typeString": "uint160"
+                                                        }
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "argumentTypes": [
+                                                        {
+                                                            "typeIdentifier": "t_uint160",
+                                                            "typeString": "uint160"
+                                                        }
+                                                    ],
+                                                    "id": 28694,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": true,
+                                                    "lValueRequested": false,
+                                                    "nodeType": "ElementaryTypeNameExpression",
+                                                    "src": "3454:7:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_type$_t_uint256_$",
+                                                        "typeString": "type(uint256)"
+                                                    },
+                                                    "typeName": {
+                                                        "id": 28693,
+                                                        "name": "uint256",
+                                                        "nodeType": "ElementaryTypeName",
+                                                        "src": "3454:7:19",
+                                                        "typeDescriptions": {}
+                                                    }
+                                                },
+                                                "id": 28699,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "kind": "typeConversion",
+                                                "lValueRequested": false,
+                                                "nameLocations": [],
+                                                "names": [],
+                                                "nodeType": "FunctionCall",
+                                                "src": "3454:39:19",
+                                                "tryCall": false,
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            ],
+                                            "id": 28692,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": true,
+                                            "lValueRequested": false,
+                                            "nodeType": "ElementaryTypeNameExpression",
+                                            "src": "3433:7:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_type$_t_bytes32_$",
+                                                "typeString": "type(bytes32)"
+                                            },
+                                            "typeName": {
+                                                "id": 28691,
+                                                "name": "bytes32",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "3433:7:19",
+                                                "typeDescriptions": {}
+                                            }
+                                        },
+                                        "id": 28700,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "typeConversion",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "3433:70:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_bytes32",
+                                            "typeString": "bytes32"
+                                        }
+                                    },
+                                    "nodeType": "VariableDeclarationStatement",
+                                    "src": "3397:106:19"
+                                },
+                                {
+                                    "assignments": [
+                                        28703
+                                    ],
+                                    "declarations": [
+                                        {
+                                            "constant": false,
+                                            "id": 28703,
+                                            "mutability": "mutable",
+                                            "name": "addr",
+                                            "nameLocation": "3521:4:19",
+                                            "nodeType": "VariableDeclaration",
+                                            "scope": 28726,
+                                            "src": "3513:12:19",
+                                            "stateVariable": false,
+                                            "storageLocation": "default",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_address",
+                                                "typeString": "address"
+                                            },
+                                            "typeName": {
+                                                "id": 28702,
+                                                "name": "address",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "3513:7:19",
+                                                "stateMutability": "nonpayable",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            },
+                                            "visibility": "internal"
+                                        }
+                                    ],
+                                    "id": 28715,
+                                    "initialValue": {
+                                        "arguments": [
+                                            {
+                                                "arguments": [
+                                                    {
+                                                        "id": 28711,
+                                                        "name": "_withdrawalCredential",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 28684,
+                                                        "src": "3656:21:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_address",
+                                                            "typeString": "address"
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": 28712,
+                                                        "name": "defaultFeeNumerator",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 28654,
+                                                        "src": "3695:19:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_uint32",
+                                                            "typeString": "uint32"
+                                                        }
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "argumentTypes": [
+                                                        {
+                                                            "typeIdentifier": "t_address",
+                                                            "typeString": "address"
+                                                        },
+                                                        {
+                                                            "typeIdentifier": "t_uint32",
+                                                            "typeString": "uint32"
+                                                        }
+                                                    ],
+                                                    "expression": {
+                                                        "argumentTypes": [
+                                                            {
+                                                                "typeIdentifier": "t_address",
+                                                                "typeString": "address"
+                                                            },
+                                                            {
+                                                                "typeIdentifier": "t_uint32",
+                                                                "typeString": "uint32"
+                                                            }
+                                                        ],
+                                                        "id": 28708,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": false,
+                                                        "lValueRequested": false,
+                                                        "nodeType": "NewExpression",
+                                                        "src": "3585:20:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_function_creation_nonpayable$_t_address_$_t_uint32_$returns$_t_contract$_RewardsCollector_$28650_$",
+                                                            "typeString": "function (address,uint32) returns (contract RewardsCollector)"
+                                                        },
+                                                        "typeName": {
+                                                            "id": 28707,
+                                                            "nodeType": "UserDefinedTypeName",
+                                                            "pathNode": {
+                                                                "id": 28706,
+                                                                "name": "RewardsCollector",
+                                                                "nameLocations": [
+                                                                    "3589:16:19"
+                                                                ],
+                                                                "nodeType": "IdentifierPath",
+                                                                "referencedDeclaration": 28650,
+                                                                "src": "3589:16:19"
+                                                            },
+                                                            "referencedDeclaration": 28650,
+                                                            "src": "3589:16:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                                                                "typeString": "contract RewardsCollector"
+                                                            }
+                                                        }
+                                                    },
+                                                    "id": 28710,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": false,
+                                                    "lValueRequested": false,
+                                                    "names": [
+                                                        "salt"
+                                                    ],
+                                                    "nodeType": "FunctionCallOptions",
+                                                    "options": [
+                                                        {
+                                                            "id": 28709,
+                                                            "name": "withdrawalCredentialBytes",
+                                                            "nodeType": "Identifier",
+                                                            "overloadedDeclarations": [],
+                                                            "referencedDeclaration": 28690,
+                                                            "src": "3612:25:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_bytes32",
+                                                                "typeString": "bytes32"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "src": "3585:53:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_function_creation_nonpayable$_t_address_$_t_uint32_$returns$_t_contract$_RewardsCollector_$28650_$salt",
+                                                        "typeString": "function (address,uint32) returns (contract RewardsCollector)"
+                                                    }
+                                                },
+                                                "id": 28713,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "kind": "functionCall",
+                                                "lValueRequested": false,
+                                                "nameLocations": [],
+                                                "names": [],
+                                                "nodeType": "FunctionCall",
+                                                "src": "3585:143:19",
+                                                "tryCall": false,
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                                                    "typeString": "contract RewardsCollector"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                                                    "typeString": "contract RewardsCollector"
+                                                }
+                                            ],
+                                            "id": 28705,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": true,
+                                            "lValueRequested": false,
+                                            "nodeType": "ElementaryTypeNameExpression",
+                                            "src": "3528:7:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_type$_t_address_$",
+                                                "typeString": "type(address)"
+                                            },
+                                            "typeName": {
+                                                "id": 28704,
+                                                "name": "address",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "3528:7:19",
+                                                "typeDescriptions": {}
+                                            }
+                                        },
+                                        "id": 28714,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "typeConversion",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "3528:210:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "nodeType": "VariableDeclarationStatement",
+                                    "src": "3513:225:19"
+                                },
+                                {
+                                    "eventCall": {
+                                        "arguments": [
+                                            {
+                                                "id": 28717,
+                                                "name": "addr",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28703,
+                                                "src": "3770:4:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            },
+                                            {
+                                                "id": 28718,
+                                                "name": "defaultFeeNumerator",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28654,
+                                                "src": "3776:19:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint32",
+                                                    "typeString": "uint32"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                },
+                                                {
+                                                    "typeIdentifier": "t_uint32",
+                                                    "typeString": "uint32"
+                                                }
+                                            ],
+                                            "id": 28716,
+                                            "name": "ContractDeployed",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28670,
+                                            "src": "3753:16:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_uint32_$returns$__$",
+                                                "typeString": "function (address,uint32)"
+                                            }
+                                        },
+                                        "id": 28719,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "3753:43:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$__$",
+                                            "typeString": "tuple()"
+                                        }
+                                    },
+                                    "id": 28720,
+                                    "nodeType": "EmitStatement",
+                                    "src": "3748:48:19"
+                                },
+                                {
+                                    "expression": {
+                                        "arguments": [
+                                            {
+                                                "id": 28723,
+                                                "name": "addr",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28703,
+                                                "src": "3821:4:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_address",
+                                                    "typeString": "address"
+                                                }
+                                            ],
+                                            "id": 28722,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": true,
+                                            "lValueRequested": false,
+                                            "nodeType": "ElementaryTypeNameExpression",
+                                            "src": "3813:8:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_type$_t_address_payable_$",
+                                                "typeString": "type(address payable)"
+                                            },
+                                            "typeName": {
+                                                "id": 28721,
+                                                "name": "address",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "3813:8:19",
+                                                "stateMutability": "payable",
+                                                "typeDescriptions": {}
+                                            }
+                                        },
+                                        "id": 28724,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "typeConversion",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "3813:13:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address_payable",
+                                            "typeString": "address payable"
+                                        }
+                                    },
+                                    "functionReturnParameters": 28688,
+                                    "id": 28725,
+                                    "nodeType": "Return",
+                                    "src": "3806:20:19"
+                                }
+                            ]
+                        },
+                        "functionSelector": "673c949d",
+                        "implemented": true,
+                        "kind": "function",
+                        "modifiers": [],
+                        "name": "createFeeContract",
+                        "nameLocation": "3291:17:19",
+                        "parameters": {
+                            "id": 28685,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28684,
+                                    "mutability": "mutable",
+                                    "name": "_withdrawalCredential",
+                                    "nameLocation": "3326:21:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28727,
+                                    "src": "3318:29:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28683,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "3318:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "3308:45:19"
+                        },
+                        "returnParameters": {
+                            "id": 28688,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28687,
+                                    "mutability": "mutable",
+                                    "name": "",
+                                    "nameLocation": "-1:-1:-1",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28727,
+                                    "src": "3370:15:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address_payable",
+                                        "typeString": "address payable"
+                                    },
+                                    "typeName": {
+                                        "id": 28686,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "3370:15:19",
+                                        "stateMutability": "payable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address_payable",
+                                            "typeString": "address payable"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "3369:17:19"
+                        },
+                        "scope": 28868,
+                        "stateMutability": "nonpayable",
+                        "virtual": false,
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28798,
+                        "nodeType": "FunctionDefinition",
+                        "src": "4203:713:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28797,
+                            "nodeType": "Block",
+                            "src": "4313:603:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "assignments": [
+                                        28735
+                                    ],
+                                    "declarations": [
+                                        {
+                                            "constant": false,
+                                            "id": 28735,
+                                            "mutability": "mutable",
+                                            "name": "bytecode",
+                                            "nameLocation": "4336:8:19",
+                                            "nodeType": "VariableDeclaration",
+                                            "scope": 28797,
+                                            "src": "4323:21:19",
+                                            "stateVariable": false,
+                                            "storageLocation": "memory",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_bytes_memory_ptr",
+                                                "typeString": "bytes"
+                                            },
+                                            "typeName": {
+                                                "id": 28734,
+                                                "name": "bytes",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "4323:5:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_bytes_storage_ptr",
+                                                    "typeString": "bytes"
+                                                }
+                                            },
+                                            "visibility": "internal"
+                                        }
+                                    ],
+                                    "id": 28740,
+                                    "initialValue": {
+                                        "expression": {
+                                            "arguments": [
+                                                {
+                                                    "id": 28737,
+                                                    "name": "RewardsCollector",
+                                                    "nodeType": "Identifier",
+                                                    "overloadedDeclarations": [],
+                                                    "referencedDeclaration": 28650,
+                                                    "src": "4352:16:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_type$_t_contract$_RewardsCollector_$28650_$",
+                                                        "typeString": "type(contract RewardsCollector)"
+                                                    }
+                                                }
+                                            ],
+                                            "expression": {
+                                                "argumentTypes": [
+                                                    {
+                                                        "typeIdentifier": "t_type$_t_contract$_RewardsCollector_$28650_$",
+                                                        "typeString": "type(contract RewardsCollector)"
+                                                    }
+                                                ],
+                                                "id": 28736,
+                                                "name": "type",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": -27,
+                                                "src": "4347:4:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_function_metatype_pure$__$returns$__$",
+                                                    "typeString": "function () pure"
+                                                }
+                                            },
+                                            "id": 28738,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": true,
+                                            "kind": "functionCall",
+                                            "lValueRequested": false,
+                                            "nameLocations": [],
+                                            "names": [],
+                                            "nodeType": "FunctionCall",
+                                            "src": "4347:22:19",
+                                            "tryCall": false,
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_magic_meta_type_t_contract$_RewardsCollector_$28650",
+                                                "typeString": "type(contract RewardsCollector)"
+                                            }
+                                        },
+                                        "id": 28739,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": true,
+                                        "lValueRequested": false,
+                                        "memberLocation": "4370:12:19",
+                                        "memberName": "creationCode",
+                                        "nodeType": "MemberAccess",
+                                        "src": "4347:35:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_bytes_memory_ptr",
+                                            "typeString": "bytes memory"
+                                        }
+                                    },
+                                    "nodeType": "VariableDeclarationStatement",
+                                    "src": "4323:59:19"
+                                },
+                                {
+                                    "expression": {
+                                        "id": 28751,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftHandSide": {
+                                            "id": 28741,
+                                            "name": "bytecode",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28735,
+                                            "src": "4392:8:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_bytes_memory_ptr",
+                                                "typeString": "bytes memory"
+                                            }
+                                        },
+                                        "nodeType": "Assignment",
+                                        "operator": "=",
+                                        "rightHandSide": {
+                                            "arguments": [
+                                                {
+                                                    "id": 28744,
+                                                    "name": "bytecode",
+                                                    "nodeType": "Identifier",
+                                                    "overloadedDeclarations": [],
+                                                    "referencedDeclaration": 28735,
+                                                    "src": "4433:8:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_bytes_memory_ptr",
+                                                        "typeString": "bytes memory"
+                                                    }
+                                                },
+                                                {
+                                                    "arguments": [
+                                                        {
+                                                            "id": 28747,
+                                                            "name": "_withdrawalCredential",
+                                                            "nodeType": "Identifier",
+                                                            "overloadedDeclarations": [],
+                                                            "referencedDeclaration": 28729,
+                                                            "src": "4466:21:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_address",
+                                                                "typeString": "address"
+                                                            }
+                                                        },
+                                                        {
+                                                            "id": 28748,
+                                                            "name": "defaultFeeNumerator",
+                                                            "nodeType": "Identifier",
+                                                            "overloadedDeclarations": [],
+                                                            "referencedDeclaration": 28654,
+                                                            "src": "4489:19:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_uint32",
+                                                                "typeString": "uint32"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "expression": {
+                                                        "argumentTypes": [
+                                                            {
+                                                                "typeIdentifier": "t_address",
+                                                                "typeString": "address"
+                                                            },
+                                                            {
+                                                                "typeIdentifier": "t_uint32",
+                                                                "typeString": "uint32"
+                                                            }
+                                                        ],
+                                                        "expression": {
+                                                            "id": 28745,
+                                                            "name": "abi",
+                                                            "nodeType": "Identifier",
+                                                            "overloadedDeclarations": [],
+                                                            "referencedDeclaration": -1,
+                                                            "src": "4455:3:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_magic_abi",
+                                                                "typeString": "abi"
+                                                            }
+                                                        },
+                                                        "id": 28746,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": true,
+                                                        "lValueRequested": false,
+                                                        "memberLocation": "4459:6:19",
+                                                        "memberName": "encode",
+                                                        "nodeType": "MemberAccess",
+                                                        "src": "4455:10:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_function_abiencode_pure$__$returns$_t_bytes_memory_ptr_$",
+                                                            "typeString": "function () pure returns (bytes memory)"
+                                                        }
+                                                    },
+                                                    "id": 28749,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": false,
+                                                    "kind": "functionCall",
+                                                    "lValueRequested": false,
+                                                    "nameLocations": [],
+                                                    "names": [],
+                                                    "nodeType": "FunctionCall",
+                                                    "src": "4455:54:19",
+                                                    "tryCall": false,
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_bytes_memory_ptr",
+                                                        "typeString": "bytes memory"
+                                                    }
+                                                }
+                                            ],
+                                            "expression": {
+                                                "argumentTypes": [
+                                                    {
+                                                        "typeIdentifier": "t_bytes_memory_ptr",
+                                                        "typeString": "bytes memory"
+                                                    },
+                                                    {
+                                                        "typeIdentifier": "t_bytes_memory_ptr",
+                                                        "typeString": "bytes memory"
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "id": 28742,
+                                                    "name": "abi",
+                                                    "nodeType": "Identifier",
+                                                    "overloadedDeclarations": [],
+                                                    "referencedDeclaration": -1,
+                                                    "src": "4403:3:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_magic_abi",
+                                                        "typeString": "abi"
+                                                    }
+                                                },
+                                                "id": 28743,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": true,
+                                                "lValueRequested": false,
+                                                "memberLocation": "4407:12:19",
+                                                "memberName": "encodePacked",
+                                                "nodeType": "MemberAccess",
+                                                "src": "4403:16:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_function_abiencodepacked_pure$__$returns$_t_bytes_memory_ptr_$",
+                                                    "typeString": "function () pure returns (bytes memory)"
+                                                }
+                                            },
+                                            "id": 28750,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "kind": "functionCall",
+                                            "lValueRequested": false,
+                                            "nameLocations": [],
+                                            "names": [],
+                                            "nodeType": "FunctionCall",
+                                            "src": "4403:116:19",
+                                            "tryCall": false,
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_bytes_memory_ptr",
+                                                "typeString": "bytes memory"
+                                            }
+                                        },
+                                        "src": "4392:127:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_bytes_memory_ptr",
+                                            "typeString": "bytes memory"
+                                        }
+                                    },
+                                    "id": 28752,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "4392:127:19"
+                                },
+                                {
+                                    "assignments": [
+                                        28754
+                                    ],
+                                    "declarations": [
+                                        {
+                                            "constant": false,
+                                            "id": 28754,
+                                            "mutability": "mutable",
+                                            "name": "withdrawalCredentialBytes",
+                                            "nameLocation": "4537:25:19",
+                                            "nodeType": "VariableDeclaration",
+                                            "scope": 28797,
+                                            "src": "4529:33:19",
+                                            "stateVariable": false,
+                                            "storageLocation": "default",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_bytes32",
+                                                "typeString": "bytes32"
+                                            },
+                                            "typeName": {
+                                                "id": 28753,
+                                                "name": "bytes32",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "4529:7:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_bytes32",
+                                                    "typeString": "bytes32"
+                                                }
+                                            },
+                                            "visibility": "internal"
+                                        }
+                                    ],
+                                    "id": 28765,
+                                    "initialValue": {
+                                        "arguments": [
+                                            {
+                                                "arguments": [
+                                                    {
+                                                        "arguments": [
+                                                            {
+                                                                "id": 28761,
+                                                                "name": "_withdrawalCredential",
+                                                                "nodeType": "Identifier",
+                                                                "overloadedDeclarations": [],
+                                                                "referencedDeclaration": 28729,
+                                                                "src": "4602:21:19",
+                                                                "typeDescriptions": {
+                                                                    "typeIdentifier": "t_address",
+                                                                    "typeString": "address"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "expression": {
+                                                            "argumentTypes": [
+                                                                {
+                                                                    "typeIdentifier": "t_address",
+                                                                    "typeString": "address"
+                                                                }
+                                                            ],
+                                                            "id": 28760,
+                                                            "isConstant": false,
+                                                            "isLValue": false,
+                                                            "isPure": true,
+                                                            "lValueRequested": false,
+                                                            "nodeType": "ElementaryTypeNameExpression",
+                                                            "src": "4594:7:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_type$_t_uint160_$",
+                                                                "typeString": "type(uint160)"
+                                                            },
+                                                            "typeName": {
+                                                                "id": 28759,
+                                                                "name": "uint160",
+                                                                "nodeType": "ElementaryTypeName",
+                                                                "src": "4594:7:19",
+                                                                "typeDescriptions": {}
+                                                            }
+                                                        },
+                                                        "id": 28762,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": false,
+                                                        "kind": "typeConversion",
+                                                        "lValueRequested": false,
+                                                        "nameLocations": [],
+                                                        "names": [],
+                                                        "nodeType": "FunctionCall",
+                                                        "src": "4594:30:19",
+                                                        "tryCall": false,
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_uint160",
+                                                            "typeString": "uint160"
+                                                        }
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "argumentTypes": [
+                                                        {
+                                                            "typeIdentifier": "t_uint160",
+                                                            "typeString": "uint160"
+                                                        }
+                                                    ],
+                                                    "id": 28758,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": true,
+                                                    "lValueRequested": false,
+                                                    "nodeType": "ElementaryTypeNameExpression",
+                                                    "src": "4586:7:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_type$_t_uint256_$",
+                                                        "typeString": "type(uint256)"
+                                                    },
+                                                    "typeName": {
+                                                        "id": 28757,
+                                                        "name": "uint256",
+                                                        "nodeType": "ElementaryTypeName",
+                                                        "src": "4586:7:19",
+                                                        "typeDescriptions": {}
+                                                    }
+                                                },
+                                                "id": 28763,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "kind": "typeConversion",
+                                                "lValueRequested": false,
+                                                "nameLocations": [],
+                                                "names": [],
+                                                "nodeType": "FunctionCall",
+                                                "src": "4586:39:19",
+                                                "tryCall": false,
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            ],
+                                            "id": 28756,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": true,
+                                            "lValueRequested": false,
+                                            "nodeType": "ElementaryTypeNameExpression",
+                                            "src": "4565:7:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_type$_t_bytes32_$",
+                                                "typeString": "type(bytes32)"
+                                            },
+                                            "typeName": {
+                                                "id": 28755,
+                                                "name": "bytes32",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "4565:7:19",
+                                                "typeDescriptions": {}
+                                            }
+                                        },
+                                        "id": 28764,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "typeConversion",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "4565:70:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_bytes32",
+                                            "typeString": "bytes32"
+                                        }
+                                    },
+                                    "nodeType": "VariableDeclarationStatement",
+                                    "src": "4529:106:19"
+                                },
+                                {
+                                    "assignments": [
+                                        28767
+                                    ],
+                                    "declarations": [
+                                        {
+                                            "constant": false,
+                                            "id": 28767,
+                                            "mutability": "mutable",
+                                            "name": "hash",
+                                            "nameLocation": "4653:4:19",
+                                            "nodeType": "VariableDeclaration",
+                                            "scope": 28797,
+                                            "src": "4645:12:19",
+                                            "stateVariable": false,
+                                            "storageLocation": "default",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_bytes32",
+                                                "typeString": "bytes32"
+                                            },
+                                            "typeName": {
+                                                "id": 28766,
+                                                "name": "bytes32",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "4645:7:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_bytes32",
+                                                    "typeString": "bytes32"
+                                                }
+                                            },
+                                            "visibility": "internal"
+                                        }
+                                    ],
+                                    "id": 28785,
+                                    "initialValue": {
+                                        "arguments": [
+                                            {
+                                                "arguments": [
+                                                    {
+                                                        "arguments": [
+                                                            {
+                                                                "hexValue": "30786666",
+                                                                "id": 28773,
+                                                                "isConstant": false,
+                                                                "isLValue": false,
+                                                                "isPure": true,
+                                                                "kind": "number",
+                                                                "lValueRequested": false,
+                                                                "nodeType": "Literal",
+                                                                "src": "4724:4:19",
+                                                                "typeDescriptions": {
+                                                                    "typeIdentifier": "t_rational_255_by_1",
+                                                                    "typeString": "int_const 255"
+                                                                },
+                                                                "value": "0xff"
+                                                            }
+                                                        ],
+                                                        "expression": {
+                                                            "argumentTypes": [
+                                                                {
+                                                                    "typeIdentifier": "t_rational_255_by_1",
+                                                                    "typeString": "int_const 255"
+                                                                }
+                                                            ],
+                                                            "id": 28772,
+                                                            "isConstant": false,
+                                                            "isLValue": false,
+                                                            "isPure": true,
+                                                            "lValueRequested": false,
+                                                            "nodeType": "ElementaryTypeNameExpression",
+                                                            "src": "4717:6:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_type$_t_bytes1_$",
+                                                                "typeString": "type(bytes1)"
+                                                            },
+                                                            "typeName": {
+                                                                "id": 28771,
+                                                                "name": "bytes1",
+                                                                "nodeType": "ElementaryTypeName",
+                                                                "src": "4717:6:19",
+                                                                "typeDescriptions": {}
+                                                            }
+                                                        },
+                                                        "id": 28774,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": true,
+                                                        "kind": "typeConversion",
+                                                        "lValueRequested": false,
+                                                        "nameLocations": [],
+                                                        "names": [],
+                                                        "nodeType": "FunctionCall",
+                                                        "src": "4717:12:19",
+                                                        "tryCall": false,
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_bytes1",
+                                                            "typeString": "bytes1"
+                                                        }
+                                                    },
+                                                    {
+                                                        "arguments": [
+                                                            {
+                                                                "id": 28777,
+                                                                "name": "this",
+                                                                "nodeType": "Identifier",
+                                                                "overloadedDeclarations": [],
+                                                                "referencedDeclaration": -28,
+                                                                "src": "4755:4:19",
+                                                                "typeDescriptions": {
+                                                                    "typeIdentifier": "t_contract$_FeeRewardsManager_$28868",
+                                                                    "typeString": "contract FeeRewardsManager"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "expression": {
+                                                            "argumentTypes": [
+                                                                {
+                                                                    "typeIdentifier": "t_contract$_FeeRewardsManager_$28868",
+                                                                    "typeString": "contract FeeRewardsManager"
+                                                                }
+                                                            ],
+                                                            "id": 28776,
+                                                            "isConstant": false,
+                                                            "isLValue": false,
+                                                            "isPure": true,
+                                                            "lValueRequested": false,
+                                                            "nodeType": "ElementaryTypeNameExpression",
+                                                            "src": "4747:7:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_type$_t_address_$",
+                                                                "typeString": "type(address)"
+                                                            },
+                                                            "typeName": {
+                                                                "id": 28775,
+                                                                "name": "address",
+                                                                "nodeType": "ElementaryTypeName",
+                                                                "src": "4747:7:19",
+                                                                "typeDescriptions": {}
+                                                            }
+                                                        },
+                                                        "id": 28778,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": false,
+                                                        "kind": "typeConversion",
+                                                        "lValueRequested": false,
+                                                        "nameLocations": [],
+                                                        "names": [],
+                                                        "nodeType": "FunctionCall",
+                                                        "src": "4747:13:19",
+                                                        "tryCall": false,
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_address",
+                                                            "typeString": "address"
+                                                        }
+                                                    },
+                                                    {
+                                                        "id": 28779,
+                                                        "name": "withdrawalCredentialBytes",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 28754,
+                                                        "src": "4778:25:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_bytes32",
+                                                            "typeString": "bytes32"
+                                                        }
+                                                    },
+                                                    {
+                                                        "arguments": [
+                                                            {
+                                                                "id": 28781,
+                                                                "name": "bytecode",
+                                                                "nodeType": "Identifier",
+                                                                "overloadedDeclarations": [],
+                                                                "referencedDeclaration": 28735,
+                                                                "src": "4831:8:19",
+                                                                "typeDescriptions": {
+                                                                    "typeIdentifier": "t_bytes_memory_ptr",
+                                                                    "typeString": "bytes memory"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "expression": {
+                                                            "argumentTypes": [
+                                                                {
+                                                                    "typeIdentifier": "t_bytes_memory_ptr",
+                                                                    "typeString": "bytes memory"
+                                                                }
+                                                            ],
+                                                            "id": 28780,
+                                                            "name": "keccak256",
+                                                            "nodeType": "Identifier",
+                                                            "overloadedDeclarations": [],
+                                                            "referencedDeclaration": -8,
+                                                            "src": "4821:9:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
+                                                                "typeString": "function (bytes memory) pure returns (bytes32)"
+                                                            }
+                                                        },
+                                                        "id": 28782,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": false,
+                                                        "kind": "functionCall",
+                                                        "lValueRequested": false,
+                                                        "nameLocations": [],
+                                                        "names": [],
+                                                        "nodeType": "FunctionCall",
+                                                        "src": "4821:19:19",
+                                                        "tryCall": false,
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_bytes32",
+                                                            "typeString": "bytes32"
+                                                        }
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "argumentTypes": [
+                                                        {
+                                                            "typeIdentifier": "t_bytes1",
+                                                            "typeString": "bytes1"
+                                                        },
+                                                        {
+                                                            "typeIdentifier": "t_address",
+                                                            "typeString": "address"
+                                                        },
+                                                        {
+                                                            "typeIdentifier": "t_bytes32",
+                                                            "typeString": "bytes32"
+                                                        },
+                                                        {
+                                                            "typeIdentifier": "t_bytes32",
+                                                            "typeString": "bytes32"
+                                                        }
+                                                    ],
+                                                    "expression": {
+                                                        "id": 28769,
+                                                        "name": "abi",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": -1,
+                                                        "src": "4683:3:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_magic_abi",
+                                                            "typeString": "abi"
+                                                        }
+                                                    },
+                                                    "id": 28770,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": true,
+                                                    "lValueRequested": false,
+                                                    "memberLocation": "4687:12:19",
+                                                    "memberName": "encodePacked",
+                                                    "nodeType": "MemberAccess",
+                                                    "src": "4683:16:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_function_abiencodepacked_pure$__$returns$_t_bytes_memory_ptr_$",
+                                                        "typeString": "function () pure returns (bytes memory)"
+                                                    }
+                                                },
+                                                "id": 28783,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "kind": "functionCall",
+                                                "lValueRequested": false,
+                                                "nameLocations": [],
+                                                "names": [],
+                                                "nodeType": "FunctionCall",
+                                                "src": "4683:171:19",
+                                                "tryCall": false,
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_bytes_memory_ptr",
+                                                    "typeString": "bytes memory"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_bytes_memory_ptr",
+                                                    "typeString": "bytes memory"
+                                                }
+                                            ],
+                                            "id": 28768,
+                                            "name": "keccak256",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": -8,
+                                            "src": "4660:9:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_keccak256_pure$_t_bytes_memory_ptr_$returns$_t_bytes32_$",
+                                                "typeString": "function (bytes memory) pure returns (bytes32)"
+                                            }
+                                        },
+                                        "id": 28784,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "4660:204:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_bytes32",
+                                            "typeString": "bytes32"
+                                        }
+                                    },
+                                    "nodeType": "VariableDeclarationStatement",
+                                    "src": "4645:219:19"
+                                },
+                                {
+                                    "expression": {
+                                        "arguments": [
+                                            {
+                                                "arguments": [
+                                                    {
+                                                        "arguments": [
+                                                            {
+                                                                "id": 28792,
+                                                                "name": "hash",
+                                                                "nodeType": "Identifier",
+                                                                "overloadedDeclarations": [],
+                                                                "referencedDeclaration": 28767,
+                                                                "src": "4902:4:19",
+                                                                "typeDescriptions": {
+                                                                    "typeIdentifier": "t_bytes32",
+                                                                    "typeString": "bytes32"
+                                                                }
+                                                            }
+                                                        ],
+                                                        "expression": {
+                                                            "argumentTypes": [
+                                                                {
+                                                                    "typeIdentifier": "t_bytes32",
+                                                                    "typeString": "bytes32"
+                                                                }
+                                                            ],
+                                                            "id": 28791,
+                                                            "isConstant": false,
+                                                            "isLValue": false,
+                                                            "isPure": true,
+                                                            "lValueRequested": false,
+                                                            "nodeType": "ElementaryTypeNameExpression",
+                                                            "src": "4897:4:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_type$_t_uint256_$",
+                                                                "typeString": "type(uint256)"
+                                                            },
+                                                            "typeName": {
+                                                                "id": 28790,
+                                                                "name": "uint",
+                                                                "nodeType": "ElementaryTypeName",
+                                                                "src": "4897:4:19",
+                                                                "typeDescriptions": {}
+                                                            }
+                                                        },
+                                                        "id": 28793,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": false,
+                                                        "kind": "typeConversion",
+                                                        "lValueRequested": false,
+                                                        "nameLocations": [],
+                                                        "names": [],
+                                                        "nodeType": "FunctionCall",
+                                                        "src": "4897:10:19",
+                                                        "tryCall": false,
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_uint256",
+                                                            "typeString": "uint256"
+                                                        }
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "argumentTypes": [
+                                                        {
+                                                            "typeIdentifier": "t_uint256",
+                                                            "typeString": "uint256"
+                                                        }
+                                                    ],
+                                                    "id": 28789,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": true,
+                                                    "lValueRequested": false,
+                                                    "nodeType": "ElementaryTypeNameExpression",
+                                                    "src": "4889:7:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_type$_t_uint160_$",
+                                                        "typeString": "type(uint160)"
+                                                    },
+                                                    "typeName": {
+                                                        "id": 28788,
+                                                        "name": "uint160",
+                                                        "nodeType": "ElementaryTypeName",
+                                                        "src": "4889:7:19",
+                                                        "typeDescriptions": {}
+                                                    }
+                                                },
+                                                "id": 28794,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "kind": "typeConversion",
+                                                "lValueRequested": false,
+                                                "nameLocations": [],
+                                                "names": [],
+                                                "nodeType": "FunctionCall",
+                                                "src": "4889:19:19",
+                                                "tryCall": false,
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint160",
+                                                    "typeString": "uint160"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_uint160",
+                                                    "typeString": "uint160"
+                                                }
+                                            ],
+                                            "id": 28787,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": true,
+                                            "lValueRequested": false,
+                                            "nodeType": "ElementaryTypeNameExpression",
+                                            "src": "4881:7:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_type$_t_address_$",
+                                                "typeString": "type(address)"
+                                            },
+                                            "typeName": {
+                                                "id": 28786,
+                                                "name": "address",
+                                                "nodeType": "ElementaryTypeName",
+                                                "src": "4881:7:19",
+                                                "typeDescriptions": {}
+                                            }
+                                        },
+                                        "id": 28795,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "typeConversion",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "4881:28:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "functionReturnParameters": 28733,
+                                    "id": 28796,
+                                    "nodeType": "Return",
+                                    "src": "4874:35:19"
+                                }
+                            ]
+                        },
+                        "functionSelector": "a900ccec",
+                        "implemented": true,
+                        "kind": "function",
+                        "modifiers": [],
+                        "name": "predictFeeContractAddress",
+                        "nameLocation": "4212:25:19",
+                        "parameters": {
+                            "id": 28730,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28729,
+                                    "mutability": "mutable",
+                                    "name": "_withdrawalCredential",
+                                    "nameLocation": "4255:21:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28798,
+                                    "src": "4247:29:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28728,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "4247:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "4237:45:19"
+                        },
+                        "returnParameters": {
+                            "id": 28733,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28732,
+                                    "mutability": "mutable",
+                                    "name": "",
+                                    "nameLocation": "-1:-1:-1",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28798,
+                                    "src": "4304:7:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28731,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "4304:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "4303:9:19"
+                        },
+                        "scope": 28868,
+                        "stateMutability": "view",
+                        "virtual": false,
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28815,
+                        "nodeType": "FunctionDefinition",
+                        "src": "4922:188:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28814,
+                            "nodeType": "Block",
+                            "src": "5035:75:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "expression": {
+                                        "arguments": [
+                                            {
+                                                "id": 28811,
+                                                "name": "_newFee",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28802,
+                                                "src": "5095:7:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint32",
+                                                    "typeString": "uint32"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_uint32",
+                                                    "typeString": "uint32"
+                                                }
+                                            ],
+                                            "expression": {
+                                                "arguments": [
+                                                    {
+                                                        "id": 28808,
+                                                        "name": "_feeContract",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 28800,
+                                                        "src": "5062:12:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_address_payable",
+                                                            "typeString": "address payable"
+                                                        }
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "argumentTypes": [
+                                                        {
+                                                            "typeIdentifier": "t_address_payable",
+                                                            "typeString": "address payable"
+                                                        }
+                                                    ],
+                                                    "id": 28807,
+                                                    "name": "RewardsCollector",
+                                                    "nodeType": "Identifier",
+                                                    "overloadedDeclarations": [],
+                                                    "referencedDeclaration": 28650,
+                                                    "src": "5045:16:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_type$_t_contract$_RewardsCollector_$28650_$",
+                                                        "typeString": "type(contract RewardsCollector)"
+                                                    }
+                                                },
+                                                "id": 28809,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "kind": "typeConversion",
+                                                "lValueRequested": false,
+                                                "nameLocations": [],
+                                                "names": [],
+                                                "nodeType": "FunctionCall",
+                                                "src": "5045:30:19",
+                                                "tryCall": false,
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                                                    "typeString": "contract RewardsCollector"
+                                                }
+                                            },
+                                            "id": 28810,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "memberLocation": "5076:18:19",
+                                            "memberName": "changeFeeNumerator",
+                                            "nodeType": "MemberAccess",
+                                            "referencedDeclaration": 28649,
+                                            "src": "5045:49:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_external_nonpayable$_t_uint32_$returns$__$",
+                                                "typeString": "function (uint32) external"
+                                            }
+                                        },
+                                        "id": 28812,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "5045:58:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$__$",
+                                            "typeString": "tuple()"
+                                        }
+                                    },
+                                    "id": 28813,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "5045:58:19"
+                                }
+                            ]
+                        },
+                        "functionSelector": "01361090",
+                        "implemented": true,
+                        "kind": "function",
+                        "modifiers": [
+                            {
+                                "id": 28805,
+                                "kind": "modifierInvocation",
+                                "modifierName": {
+                                    "id": 28804,
+                                    "name": "onlyOwner",
+                                    "nameLocations": [
+                                        "5025:9:19"
+                                    ],
+                                    "nodeType": "IdentifierPath",
+                                    "referencedDeclaration": 31,
+                                    "src": "5025:9:19"
+                                },
+                                "nodeType": "ModifierInvocation",
+                                "src": "5025:9:19"
+                            }
+                        ],
+                        "name": "changeFeeNumerator",
+                        "nameLocation": "4931:18:19",
+                        "parameters": {
+                            "id": 28803,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28800,
+                                    "mutability": "mutable",
+                                    "name": "_feeContract",
+                                    "nameLocation": "4975:12:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28815,
+                                    "src": "4959:28:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address_payable",
+                                        "typeString": "address payable"
+                                    },
+                                    "typeName": {
+                                        "id": 28799,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "4959:15:19",
+                                        "stateMutability": "payable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address_payable",
+                                            "typeString": "address payable"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                },
+                                {
+                                    "constant": false,
+                                    "id": 28802,
+                                    "mutability": "mutable",
+                                    "name": "_newFee",
+                                    "nameLocation": "5004:7:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28815,
+                                    "src": "4997:14:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_uint32",
+                                        "typeString": "uint32"
+                                    },
+                                    "typeName": {
+                                        "id": 28801,
+                                        "name": "uint32",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "4997:6:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_uint32",
+                                            "typeString": "uint32"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "4949:68:19"
+                        },
+                        "returnParameters": {
+                            "id": 28806,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "5035:0:19"
+                        },
+                        "scope": 28868,
+                        "stateMutability": "nonpayable",
+                        "virtual": false,
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28843,
+                        "nodeType": "FunctionDefinition",
+                        "src": "5116:231:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28842,
+                            "nodeType": "Block",
+                            "src": "5207:140:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "body": {
+                                        "id": 28840,
+                                        "nodeType": "Block",
+                                        "src": "5266:75:19",
+                                        "statements": [
+                                            {
+                                                "expression": {
+                                                    "arguments": [],
+                                                    "expression": {
+                                                        "argumentTypes": [],
+                                                        "expression": {
+                                                            "arguments": [
+                                                                {
+                                                                    "baseExpression": {
+                                                                        "id": 28833,
+                                                                        "name": "feeAddresses",
+                                                                        "nodeType": "Identifier",
+                                                                        "overloadedDeclarations": [],
+                                                                        "referencedDeclaration": 28818,
+                                                                        "src": "5297:12:19",
+                                                                        "typeDescriptions": {
+                                                                            "typeIdentifier": "t_array$_t_address_payable_$dyn_calldata_ptr",
+                                                                            "typeString": "address payable[] calldata"
+                                                                        }
+                                                                    },
+                                                                    "id": 28835,
+                                                                    "indexExpression": {
+                                                                        "id": 28834,
+                                                                        "name": "i",
+                                                                        "nodeType": "Identifier",
+                                                                        "overloadedDeclarations": [],
+                                                                        "referencedDeclaration": 28822,
+                                                                        "src": "5310:1:19",
+                                                                        "typeDescriptions": {
+                                                                            "typeIdentifier": "t_uint32",
+                                                                            "typeString": "uint32"
+                                                                        }
+                                                                    },
+                                                                    "isConstant": false,
+                                                                    "isLValue": false,
+                                                                    "isPure": false,
+                                                                    "lValueRequested": false,
+                                                                    "nodeType": "IndexAccess",
+                                                                    "src": "5297:15:19",
+                                                                    "typeDescriptions": {
+                                                                        "typeIdentifier": "t_address_payable",
+                                                                        "typeString": "address payable"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "expression": {
+                                                                "argumentTypes": [
+                                                                    {
+                                                                        "typeIdentifier": "t_address_payable",
+                                                                        "typeString": "address payable"
+                                                                    }
+                                                                ],
+                                                                "id": 28832,
+                                                                "name": "RewardsCollector",
+                                                                "nodeType": "Identifier",
+                                                                "overloadedDeclarations": [],
+                                                                "referencedDeclaration": 28650,
+                                                                "src": "5280:16:19",
+                                                                "typeDescriptions": {
+                                                                    "typeIdentifier": "t_type$_t_contract$_RewardsCollector_$28650_$",
+                                                                    "typeString": "type(contract RewardsCollector)"
+                                                                }
+                                                            },
+                                                            "id": 28836,
+                                                            "isConstant": false,
+                                                            "isLValue": false,
+                                                            "isPure": false,
+                                                            "kind": "typeConversion",
+                                                            "lValueRequested": false,
+                                                            "nameLocations": [],
+                                                            "names": [],
+                                                            "nodeType": "FunctionCall",
+                                                            "src": "5280:33:19",
+                                                            "tryCall": false,
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_contract$_RewardsCollector_$28650",
+                                                                "typeString": "contract RewardsCollector"
+                                                            }
+                                                        },
+                                                        "id": 28837,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": false,
+                                                        "lValueRequested": false,
+                                                        "memberLocation": "5314:14:19",
+                                                        "memberName": "collectRewards",
+                                                        "nodeType": "MemberAccess",
+                                                        "referencedDeclaration": 28610,
+                                                        "src": "5280:48:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_function_external_payable$__$returns$__$",
+                                                            "typeString": "function () payable external"
+                                                        }
+                                                    },
+                                                    "id": 28838,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": false,
+                                                    "kind": "functionCall",
+                                                    "lValueRequested": false,
+                                                    "nameLocations": [],
+                                                    "names": [],
+                                                    "nodeType": "FunctionCall",
+                                                    "src": "5280:50:19",
+                                                    "tryCall": false,
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_tuple$__$",
+                                                        "typeString": "tuple()"
+                                                    }
+                                                },
+                                                "id": 28839,
+                                                "nodeType": "ExpressionStatement",
+                                                "src": "5280:50:19"
+                                            }
+                                        ]
+                                    },
+                                    "condition": {
+                                        "commonType": {
+                                            "typeIdentifier": "t_uint256",
+                                            "typeString": "uint256"
+                                        },
+                                        "id": 28828,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "lValueRequested": false,
+                                        "leftExpression": {
+                                            "id": 28825,
+                                            "name": "i",
+                                            "nodeType": "Identifier",
+                                            "overloadedDeclarations": [],
+                                            "referencedDeclaration": 28822,
+                                            "src": "5236:1:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "nodeType": "BinaryOperation",
+                                        "operator": "<",
+                                        "rightExpression": {
+                                            "expression": {
+                                                "id": 28826,
+                                                "name": "feeAddresses",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28818,
+                                                "src": "5240:12:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_array$_t_address_payable_$dyn_calldata_ptr",
+                                                    "typeString": "address payable[] calldata"
+                                                }
+                                            },
+                                            "id": 28827,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "memberLocation": "5253:6:19",
+                                            "memberName": "length",
+                                            "nodeType": "MemberAccess",
+                                            "src": "5240:19:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint256",
+                                                "typeString": "uint256"
+                                            }
+                                        },
+                                        "src": "5236:23:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_bool",
+                                            "typeString": "bool"
+                                        }
+                                    },
+                                    "id": 28841,
+                                    "initializationExpression": {
+                                        "assignments": [
+                                            28822
+                                        ],
+                                        "declarations": [
+                                            {
+                                                "constant": false,
+                                                "id": 28822,
+                                                "mutability": "mutable",
+                                                "name": "i",
+                                                "nameLocation": "5229:1:19",
+                                                "nodeType": "VariableDeclaration",
+                                                "scope": 28841,
+                                                "src": "5222:8:19",
+                                                "stateVariable": false,
+                                                "storageLocation": "default",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint32",
+                                                    "typeString": "uint32"
+                                                },
+                                                "typeName": {
+                                                    "id": 28821,
+                                                    "name": "uint32",
+                                                    "nodeType": "ElementaryTypeName",
+                                                    "src": "5222:6:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_uint32",
+                                                        "typeString": "uint32"
+                                                    }
+                                                },
+                                                "visibility": "internal"
+                                            }
+                                        ],
+                                        "id": 28824,
+                                        "initialValue": {
+                                            "hexValue": "30",
+                                            "id": 28823,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": true,
+                                            "kind": "number",
+                                            "lValueRequested": false,
+                                            "nodeType": "Literal",
+                                            "src": "5233:1:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_rational_0_by_1",
+                                                "typeString": "int_const 0"
+                                            },
+                                            "value": "0"
+                                        },
+                                        "nodeType": "VariableDeclarationStatement",
+                                        "src": "5222:12:19"
+                                    },
+                                    "loopExpression": {
+                                        "expression": {
+                                            "id": 28830,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "nodeType": "UnaryOperation",
+                                            "operator": "++",
+                                            "prefix": true,
+                                            "src": "5261:3:19",
+                                            "subExpression": {
+                                                "id": 28829,
+                                                "name": "i",
+                                                "nodeType": "Identifier",
+                                                "overloadedDeclarations": [],
+                                                "referencedDeclaration": 28822,
+                                                "src": "5263:1:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint32",
+                                                    "typeString": "uint32"
+                                                }
+                                            },
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_uint32",
+                                                "typeString": "uint32"
+                                            }
+                                        },
+                                        "id": 28831,
+                                        "nodeType": "ExpressionStatement",
+                                        "src": "5261:3:19"
+                                    },
+                                    "nodeType": "ForStatement",
+                                    "src": "5217:124:19"
+                                }
+                            ]
+                        },
+                        "functionSelector": "2630be4e",
+                        "implemented": true,
+                        "kind": "function",
+                        "modifiers": [],
+                        "name": "batchCollectRewards",
+                        "nameLocation": "5125:19:19",
+                        "parameters": {
+                            "id": 28819,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28818,
+                                    "mutability": "mutable",
+                                    "name": "feeAddresses",
+                                    "nameLocation": "5181:12:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28843,
+                                    "src": "5154:39:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "calldata",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_array$_t_address_payable_$dyn_calldata_ptr",
+                                        "typeString": "address payable[]"
+                                    },
+                                    "typeName": {
+                                        "baseType": {
+                                            "id": 28816,
+                                            "name": "address",
+                                            "nodeType": "ElementaryTypeName",
+                                            "src": "5154:15:19",
+                                            "stateMutability": "payable",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_address_payable",
+                                                "typeString": "address payable"
+                                            }
+                                        },
+                                        "id": 28817,
+                                        "nodeType": "ArrayTypeName",
+                                        "src": "5154:17:19",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_array$_t_address_payable_$dyn_storage_ptr",
+                                            "typeString": "address payable[]"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "5144:55:19"
+                        },
+                        "returnParameters": {
+                            "id": 28820,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "5207:0:19"
+                        },
+                        "scope": 28868,
+                        "stateMutability": "nonpayable",
+                        "virtual": false,
+                        "visibility": "public"
+                    },
+                    {
+                        "id": 28847,
+                        "nodeType": "FunctionDefinition",
+                        "src": "5353:29:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28846,
+                            "nodeType": "Block",
+                            "src": "5380:2:19",
+                            "nodes": [],
+                            "statements": []
+                        },
+                        "implemented": true,
+                        "kind": "receive",
+                        "modifiers": [],
+                        "name": "",
+                        "nameLocation": "-1:-1:-1",
+                        "parameters": {
+                            "id": 28844,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "5360:2:19"
+                        },
+                        "returnParameters": {
+                            "id": 28845,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "5380:0:19"
+                        },
+                        "scope": 28868,
+                        "stateMutability": "payable",
+                        "virtual": false,
+                        "visibility": "external"
+                    },
+                    {
+                        "id": 28867,
+                        "nodeType": "FunctionDefinition",
+                        "src": "5436:111:19",
+                        "nodes": [],
+                        "body": {
+                            "id": 28866,
+                            "nodeType": "Block",
+                            "src": "5485:62:19",
+                            "nodes": [],
+                            "statements": [
+                                {
+                                    "expression": {
+                                        "arguments": [
+                                            {
+                                                "expression": {
+                                                    "arguments": [
+                                                        {
+                                                            "id": 28861,
+                                                            "name": "this",
+                                                            "nodeType": "Identifier",
+                                                            "overloadedDeclarations": [],
+                                                            "referencedDeclaration": -28,
+                                                            "src": "5526:4:19",
+                                                            "typeDescriptions": {
+                                                                "typeIdentifier": "t_contract$_FeeRewardsManager_$28868",
+                                                                "typeString": "contract FeeRewardsManager"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "expression": {
+                                                        "argumentTypes": [
+                                                            {
+                                                                "typeIdentifier": "t_contract$_FeeRewardsManager_$28868",
+                                                                "typeString": "contract FeeRewardsManager"
+                                                            }
+                                                        ],
+                                                        "id": 28860,
+                                                        "isConstant": false,
+                                                        "isLValue": false,
+                                                        "isPure": true,
+                                                        "lValueRequested": false,
+                                                        "nodeType": "ElementaryTypeNameExpression",
+                                                        "src": "5518:7:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_type$_t_address_$",
+                                                            "typeString": "type(address)"
+                                                        },
+                                                        "typeName": {
+                                                            "id": 28859,
+                                                            "name": "address",
+                                                            "nodeType": "ElementaryTypeName",
+                                                            "src": "5518:7:19",
+                                                            "typeDescriptions": {}
+                                                        }
+                                                    },
+                                                    "id": 28862,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": false,
+                                                    "kind": "typeConversion",
+                                                    "lValueRequested": false,
+                                                    "nameLocations": [],
+                                                    "names": [],
+                                                    "nodeType": "FunctionCall",
+                                                    "src": "5518:13:19",
+                                                    "tryCall": false,
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_address",
+                                                        "typeString": "address"
+                                                    }
+                                                },
+                                                "id": 28863,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "lValueRequested": false,
+                                                "memberLocation": "5532:7:19",
+                                                "memberName": "balance",
+                                                "nodeType": "MemberAccess",
+                                                "src": "5518:21:19",
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            }
+                                        ],
+                                        "expression": {
+                                            "argumentTypes": [
+                                                {
+                                                    "typeIdentifier": "t_uint256",
+                                                    "typeString": "uint256"
+                                                }
+                                            ],
+                                            "expression": {
+                                                "arguments": [
+                                                    {
+                                                        "id": 28856,
+                                                        "name": "addr",
+                                                        "nodeType": "Identifier",
+                                                        "overloadedDeclarations": [],
+                                                        "referencedDeclaration": 28849,
+                                                        "src": "5503:4:19",
+                                                        "typeDescriptions": {
+                                                            "typeIdentifier": "t_address",
+                                                            "typeString": "address"
+                                                        }
+                                                    }
+                                                ],
+                                                "expression": {
+                                                    "argumentTypes": [
+                                                        {
+                                                            "typeIdentifier": "t_address",
+                                                            "typeString": "address"
+                                                        }
+                                                    ],
+                                                    "id": 28855,
+                                                    "isConstant": false,
+                                                    "isLValue": false,
+                                                    "isPure": true,
+                                                    "lValueRequested": false,
+                                                    "nodeType": "ElementaryTypeNameExpression",
+                                                    "src": "5495:8:19",
+                                                    "typeDescriptions": {
+                                                        "typeIdentifier": "t_type$_t_address_payable_$",
+                                                        "typeString": "type(address payable)"
+                                                    },
+                                                    "typeName": {
+                                                        "id": 28854,
+                                                        "name": "address",
+                                                        "nodeType": "ElementaryTypeName",
+                                                        "src": "5495:8:19",
+                                                        "stateMutability": "payable",
+                                                        "typeDescriptions": {}
+                                                    }
+                                                },
+                                                "id": 28857,
+                                                "isConstant": false,
+                                                "isLValue": false,
+                                                "isPure": false,
+                                                "kind": "typeConversion",
+                                                "lValueRequested": false,
+                                                "nameLocations": [],
+                                                "names": [],
+                                                "nodeType": "FunctionCall",
+                                                "src": "5495:13:19",
+                                                "tryCall": false,
+                                                "typeDescriptions": {
+                                                    "typeIdentifier": "t_address_payable",
+                                                    "typeString": "address payable"
+                                                }
+                                            },
+                                            "id": 28858,
+                                            "isConstant": false,
+                                            "isLValue": false,
+                                            "isPure": false,
+                                            "lValueRequested": false,
+                                            "memberLocation": "5509:8:19",
+                                            "memberName": "transfer",
+                                            "nodeType": "MemberAccess",
+                                            "src": "5495:22:19",
+                                            "typeDescriptions": {
+                                                "typeIdentifier": "t_function_transfer_nonpayable$_t_uint256_$returns$__$",
+                                                "typeString": "function (uint256)"
+                                            }
+                                        },
+                                        "id": 28864,
+                                        "isConstant": false,
+                                        "isLValue": false,
+                                        "isPure": false,
+                                        "kind": "functionCall",
+                                        "lValueRequested": false,
+                                        "nameLocations": [],
+                                        "names": [],
+                                        "nodeType": "FunctionCall",
+                                        "src": "5495:45:19",
+                                        "tryCall": false,
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_tuple$__$",
+                                            "typeString": "tuple()"
+                                        }
+                                    },
+                                    "id": 28865,
+                                    "nodeType": "ExpressionStatement",
+                                    "src": "5495:45:19"
+                                }
+                            ]
+                        },
+                        "functionSelector": "6a953e09",
+                        "implemented": true,
+                        "kind": "function",
+                        "modifiers": [
+                            {
+                                "id": 28852,
+                                "kind": "modifierInvocation",
+                                "modifierName": {
+                                    "id": 28851,
+                                    "name": "onlyOwner",
+                                    "nameLocations": [
+                                        "5475:9:19"
+                                    ],
+                                    "nodeType": "IdentifierPath",
+                                    "referencedDeclaration": 31,
+                                    "src": "5475:9:19"
+                                },
+                                "nodeType": "ModifierInvocation",
+                                "src": "5475:9:19"
+                            }
+                        ],
+                        "name": "getEth",
+                        "nameLocation": "5445:6:19",
+                        "parameters": {
+                            "id": 28850,
+                            "nodeType": "ParameterList",
+                            "parameters": [
+                                {
+                                    "constant": false,
+                                    "id": 28849,
+                                    "mutability": "mutable",
+                                    "name": "addr",
+                                    "nameLocation": "5460:4:19",
+                                    "nodeType": "VariableDeclaration",
+                                    "scope": 28867,
+                                    "src": "5452:12:19",
+                                    "stateVariable": false,
+                                    "storageLocation": "default",
+                                    "typeDescriptions": {
+                                        "typeIdentifier": "t_address",
+                                        "typeString": "address"
+                                    },
+                                    "typeName": {
+                                        "id": 28848,
+                                        "name": "address",
+                                        "nodeType": "ElementaryTypeName",
+                                        "src": "5452:7:19",
+                                        "stateMutability": "nonpayable",
+                                        "typeDescriptions": {
+                                            "typeIdentifier": "t_address",
+                                            "typeString": "address"
+                                        }
+                                    },
+                                    "visibility": "internal"
+                                }
+                            ],
+                            "src": "5451:14:19"
+                        },
+                        "returnParameters": {
+                            "id": 28853,
+                            "nodeType": "ParameterList",
+                            "parameters": [],
+                            "src": "5485:0:19"
+                        },
+                        "scope": 28868,
+                        "stateMutability": "nonpayable",
+                        "virtual": false,
+                        "visibility": "external"
+                    }
+                ],
+                "abstract": false,
+                "baseContracts": [
+                    {
+                        "baseName": {
+                            "id": 28651,
+                            "name": "Ownable",
+                            "nameLocations": [
+                                "2918:7:19"
+                            ],
+                            "nodeType": "IdentifierPath",
+                            "referencedDeclaration": 112,
+                            "src": "2918:7:19"
+                        },
+                        "id": 28652,
+                        "nodeType": "InheritanceSpecifier",
+                        "src": "2918:7:19"
+                    }
+                ],
+                "canonicalName": "FeeRewardsManager",
+                "contractDependencies": [
+                    28650
+                ],
+                "contractKind": "contract",
+                "fullyImplemented": true,
+                "linearizedBaseContracts": [
+                    28868,
+                    112,
+                    134
+                ],
+                "name": "FeeRewardsManager",
+                "nameLocation": "2897:17:19",
+                "scope": 28869,
+                "usedErrors": [],
+                "usedEvents": [
+                    13,
+                    28670
+                ]
+            }
+        ],
+        "license": "BSD-3-Clause"
+    },
+    "id": 19
+}


### PR DESCRIPTION
Adds ability to deploy compiled contracts, this should be favoured instead of compiling contracts with solc, it's more reliable because we can use the exact same bytecode that is deployed in the Ethereum blockchain.

For the fee manager contract we need 2 contracts, first the library and then the main contract, we deploy the library contract and substitute a placeholder inside the compiled binary with the library's address.